### PR TITLE
Remove use of map global variable

### DIFF
--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -9,7 +9,7 @@
       rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
     <script src="script.js"></script>
-    <script async defer src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDtnOIOa1q7Mwn8OeRkeXdNPxpbaWT2ZFw&callback=initMap" 
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDtnOIOa1q7Mwn8OeRkeXdNPxpbaWT2ZFw" 
       type="text/javascript"></script>
   </head>
   <body>

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -58,7 +58,7 @@ function showMessageOnInfoWindow(message, position, map, infoWindow) {
 }
 
 window.onload = () => {
-  document.getElementById("form-container").style.display = "none";
+  document.getElementById('form-container').style.display = 'none';
   document.getElementById('report-button').addEventListener('click', showReportForm);
   const map = initMap();
   loadPoliceReports(map);

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-let map;
-
 function initMap() {
-  map = new google.maps.Map(document.getElementById("map"), {
+  const map = new google.maps.Map(document.getElementById("map"), {
     center: { lat: -34.397, lng: 150.644 },
     zoom: 5,
   });
-  const infoWindow = new google.maps.InfoWindow();
-  displayUserLocation(map, infoWindow);
+  return map;
 }
 
-function displayUserLocation(map, infoWindow) {
+function displayUserLocation(map) {
+  const infoWindow = new google.maps.InfoWindow();
+
   if (!navigator.geolocation) {
     showMessageOnInfoWindow(
       "Error: Your browser doesn't support geolocation.",
@@ -61,14 +60,16 @@ function showMessageOnInfoWindow(message, position, map, infoWindow) {
 window.onload = () => {
   document.getElementById("form-container").style.display = "none";
   document.getElementById('report-button').addEventListener('click', showReportForm);
-  loadPoliceReports();
+  const map = initMap();
+  loadPoliceReports(map);
+  displayUserLocation(map);
 };
 
 function showReportForm() {
   document.getElementById("form-container").style.display = "block";
 }
 
-async function loadPoliceReports() {
+async function loadPoliceReports(map) {
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']
   for (const file_name of FILE_NAMES) {
     const data = await fetch('../data/' + file_name + '.json');


### PR DESCRIPTION
Previously, I used global variables to access map in different functions. Now, I pass the map variable as a parameter to functions instead by returning a map in the initialization function. 