### PR TITLE
Filter the police reports based on user preferences 

### DIFF
--- a/web-app/preprocess/csvToJson.py
+++ b/web-app/preprocess/csvToJson.py
@@ -17,7 +17,7 @@ def csvToJson(filename):
         csvReader = csv.DictReader(csvFile)
         for rows in csvReader:
             entry = {
-                'month': rows['Month'],
+                'yearMonth': rows['Month'],
                 'longitude': rows['Longitude'],
                 'latitude': rows['Latitude'],
                 'crimeType': rows['Crime type']

--- a/web-app/src/main/webapp/css/style.css
+++ b/web-app/src/main/webapp/css/style.css
@@ -35,6 +35,7 @@
   box-shadow: 10px 0 10px rgba(0, 0, 0, 0.4);
   color: #e0e0e0;
   height: 100vh;
+  overflow: scroll;
   position: absolute;
   width: 600px;
 }

--- a/web-app/src/main/webapp/data/2019_12_london.json
+++ b/web-app/src/main/webapp/data/2019_12_london.json
@@ -1,5292 +1,5292 @@
 [
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098023",
     "latitude": "51.519905",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095892",
     "latitude": "51.516391",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098023",
     "latitude": "51.519905",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095892",
     "latitude": "51.516391",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093948",
     "latitude": "51.518077",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093948",
     "latitude": "51.518077",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093969",
     "latitude": "51.519300",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089596",
     "latitude": "51.518743",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089596",
     "latitude": "51.518743",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093969",
     "latitude": "51.519300",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077513",
     "latitude": "51.515075",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077392",
     "latitude": "51.516233",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077513",
     "latitude": "51.515075",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077513",
     "latitude": "51.515075",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074115",
     "latitude": "51.511224",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079607",
     "latitude": "51.515657",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077451",
     "latitude": "51.515523",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076592",
     "latitude": "51.514367",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075508",
     "latitude": "51.514763",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076833",
     "latitude": "51.513769",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085173",
     "latitude": "51.518680",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080665",
     "latitude": "51.509344",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091108",
     "latitude": "51.511529",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084105",
     "latitude": "51.515281",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081832",
     "latitude": "51.514507",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102647",
     "latitude": "51.513721",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091506",
     "latitude": "51.513037",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090804",
     "latitude": "51.511560",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082527",
     "latitude": "51.512027",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082527",
     "latitude": "51.512027",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087666",
     "latitude": "51.511122",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086416",
     "latitude": "51.516191",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086416",
     "latitude": "51.516191",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090797",
     "latitude": "51.514482",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094206",
     "latitude": "51.511210",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088552",
     "latitude": "51.510282",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084621",
     "latitude": "51.510200",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082512",
     "latitude": "51.512387",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091151",
     "latitude": "51.514992",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080446",
     "latitude": "51.516283",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083417",
     "latitude": "51.513148",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085173",
     "latitude": "51.518680",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083079",
     "latitude": "51.511578",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096643",
     "latitude": "51.512545",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091151",
     "latitude": "51.516026",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091258",
     "latitude": "51.514157",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089040",
     "latitude": "51.512745",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089838",
     "latitude": "51.516067",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083242",
     "latitude": "51.512165",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101959",
     "latitude": "51.513297",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088075",
     "latitude": "51.512388",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087086",
     "latitude": "51.512596",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079283",
     "latitude": "51.511021",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096643",
     "latitude": "51.512545",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097213",
     "latitude": "51.511322",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101959",
     "latitude": "51.513297",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079283",
     "latitude": "51.511021",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088233",
     "latitude": "51.515484",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101575",
     "latitude": "51.513857",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090985",
     "latitude": "51.516886",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083417",
     "latitude": "51.513148",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081070",
     "latitude": "51.512390",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092926",
     "latitude": "51.511477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083120",
     "latitude": "51.510598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084105",
     "latitude": "51.515281",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096643",
     "latitude": "51.512545",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088995",
     "latitude": "51.512088",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101575",
     "latitude": "51.513857",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084201",
     "latitude": "51.510949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091151",
     "latitude": "51.516026",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080446",
     "latitude": "51.516283",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084201",
     "latitude": "51.510949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079162",
     "latitude": "51.514940",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090804",
     "latitude": "51.511560",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084105",
     "latitude": "51.515281",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085086",
     "latitude": "51.515621",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084621",
     "latitude": "51.510200",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087153",
     "latitude": "51.518910",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084201",
     "latitude": "51.510949",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101575",
     "latitude": "51.513857",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087666",
     "latitude": "51.511122",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089582",
     "latitude": "51.511495",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079287",
     "latitude": "51.511956",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083417",
     "latitude": "51.513148",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082066",
     "latitude": "51.516147",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077029",
     "latitude": "51.510148",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084621",
     "latitude": "51.510200",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085173",
     "latitude": "51.518680",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083587",
     "latitude": "51.512171",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088727",
     "latitude": "51.513333",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083079",
     "latitude": "51.511578",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080573",
     "latitude": "51.516006",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094206",
     "latitude": "51.511210",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089582",
     "latitude": "51.511495",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087787",
     "latitude": "51.510647",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.090203",
     "latitude": "51.511118",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082512",
     "latitude": "51.512387",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094206",
     "latitude": "51.511210",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087670",
     "latitude": "51.516877",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083587",
     "latitude": "51.512171",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089090",
     "latitude": "51.513258",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087549",
     "latitude": "51.514276",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.107793",
     "latitude": "51.515450",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.107793",
     "latitude": "51.515450",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110471",
     "latitude": "51.517265",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110471",
     "latitude": "51.517265",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.107793",
     "latitude": "51.515450",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106214",
     "latitude": "51.513905",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098148",
     "latitude": "51.517938",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098500",
     "latitude": "51.519526",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106357",
     "latitude": "51.512549",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108459",
     "latitude": "51.512934",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.103280",
     "latitude": "51.514109",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.098886",
     "latitude": "51.519254",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102812",
     "latitude": "51.517042",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108164",
     "latitude": "51.516571",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108018",
     "latitude": "51.511749",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110735",
     "latitude": "51.517836",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.103494",
     "latitude": "51.518654",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.099848",
     "latitude": "51.519350",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.107672",
     "latitude": "51.517678",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.108018",
     "latitude": "51.511749",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.103494",
     "latitude": "51.518654",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.103494",
     "latitude": "51.518654",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105157",
     "latitude": "51.513330",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091394",
     "latitude": "51.528493",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.109145",
     "latitude": "51.567709",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.105566",
     "latitude": "51.564585",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.086655",
     "latitude": "51.519783",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.089858",
     "latitude": "51.520744",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087486",
     "latitude": "51.519896",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.087486",
     "latitude": "51.519896",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.092413",
     "latitude": "51.522026",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "0.004136",
     "latitude": "51.546270",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.068262",
     "latitude": "51.522863",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076067",
     "latitude": "51.516894",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076747",
     "latitude": "51.517184",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079080",
     "latitude": "51.519615",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079080",
     "latitude": "51.519615",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.078591",
     "latitude": "51.520290",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.077601",
     "latitude": "51.518799",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079080",
     "latitude": "51.519615",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.073849",
     "latitude": "51.514457",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.073180",
     "latitude": "51.513915",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.068161",
     "latitude": "51.509930",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076031",
     "latitude": "51.509547",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.076031",
     "latitude": "51.509547",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.003592",
     "latitude": "51.588496",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "0.010631",
     "latitude": "51.572867",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.112770",
     "latitude": "51.512536",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "-0.113726",
     "latitude": "51.511040",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Robbery"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2019-12",
+    "yearMonth": "2019-12",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/data/2020_01_london.json
+++ b/web-app/src/main/webapp/data/2020_01_london.json
@@ -1,4782 +1,4782 @@
 [
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.106453",
     "latitude": "51.518207",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.117684",
     "latitude": "51.522003",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.113256",
     "latitude": "51.516824",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111962",
     "latitude": "51.518494",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098023",
     "latitude": "51.519905",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096348",
     "latitude": "51.515472",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098062",
     "latitude": "51.517577",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098062",
     "latitude": "51.517577",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092517",
     "latitude": "51.520580",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089596",
     "latitude": "51.518743",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092517",
     "latitude": "51.520580",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091440",
     "latitude": "51.519807",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093057",
     "latitude": "51.520085",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093030",
     "latitude": "51.517612",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092517",
     "latitude": "51.520580",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094115",
     "latitude": "51.516497",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096114",
     "latitude": "51.520747",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074896",
     "latitude": "51.514933",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073065",
     "latitude": "51.511180",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076080",
     "latitude": "51.511445",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075508",
     "latitude": "51.514763",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077451",
     "latitude": "51.515523",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074115",
     "latitude": "51.511224",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076044",
     "latitude": "51.512650",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075508",
     "latitude": "51.514763",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083150",
     "latitude": "51.510913",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084566",
     "latitude": "51.517690",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083618",
     "latitude": "51.517288",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081912",
     "latitude": "51.516370",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.099716",
     "latitude": "51.511435",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083150",
     "latitude": "51.510913",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094197",
     "latitude": "51.510734",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083587",
     "latitude": "51.512171",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086550",
     "latitude": "51.512651",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101073",
     "latitude": "51.513453",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088614",
     "latitude": "51.516371",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088473",
     "latitude": "51.518374",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102668",
     "latitude": "51.513560",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092267",
     "latitude": "51.511745",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078308",
     "latitude": "51.518091",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102668",
     "latitude": "51.513560",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101959",
     "latitude": "51.513297",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083645",
     "latitude": "51.512504",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089647",
     "latitude": "51.513384",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092268",
     "latitude": "51.514461",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094933",
     "latitude": "51.513129",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102647",
     "latitude": "51.513721",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094933",
     "latitude": "51.513129",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094197",
     "latitude": "51.510734",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102668",
     "latitude": "51.513560",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079162",
     "latitude": "51.514940",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078308",
     "latitude": "51.518091",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087086",
     "latitude": "51.512596",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096846",
     "latitude": "51.511478",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090804",
     "latitude": "51.511560",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089090",
     "latitude": "51.513258",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078308",
     "latitude": "51.518091",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081938",
     "latitude": "51.513007",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082512",
     "latitude": "51.512387",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091151",
     "latitude": "51.516026",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078308",
     "latitude": "51.518091",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090419",
     "latitude": "51.514917",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090837",
     "latitude": "51.511470",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087525",
     "latitude": "51.510364",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090203",
     "latitude": "51.511118",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084095",
     "latitude": "51.516900",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078488",
     "latitude": "51.517923",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077935",
     "latitude": "51.514281",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082571",
     "latitude": "51.514753",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101575",
     "latitude": "51.513857",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102647",
     "latitude": "51.513721",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.091084",
     "latitude": "51.513830",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083079",
     "latitude": "51.511578",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102647",
     "latitude": "51.513721",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086550",
     "latitude": "51.512651",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085355",
     "latitude": "51.510563",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088225",
     "latitude": "51.514656",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087086",
     "latitude": "51.512596",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083506",
     "latitude": "51.509993",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086550",
     "latitude": "51.512651",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089040",
     "latitude": "51.512745",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.084105",
     "latitude": "51.515281",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.089647",
     "latitude": "51.513384",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086624",
     "latitude": "51.511923",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087763",
     "latitude": "51.516393",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107148",
     "latitude": "51.511879",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098500",
     "latitude": "51.519526",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108418",
     "latitude": "51.513581",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.103280",
     "latitude": "51.514109",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107147",
     "latitude": "51.517130",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108418",
     "latitude": "51.513581",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098148",
     "latitude": "51.517938",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.103419",
     "latitude": "51.514921",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.099933",
     "latitude": "51.519720",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098148",
     "latitude": "51.517938",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108418",
     "latitude": "51.513581",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107672",
     "latitude": "51.517678",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098886",
     "latitude": "51.519254",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.110471",
     "latitude": "51.517265",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.099848",
     "latitude": "51.519350",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.098886",
     "latitude": "51.519254",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104134",
     "latitude": "51.514699",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102794",
     "latitude": "51.515037",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102794",
     "latitude": "51.515037",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102721",
     "latitude": "51.515404",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.103494",
     "latitude": "51.518654",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102794",
     "latitude": "51.515037",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107926",
     "latitude": "51.516414",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107926",
     "latitude": "51.516414",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108175",
     "latitude": "51.512830",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.107147",
     "latitude": "51.517130",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.082425",
     "latitude": "51.572419",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.110394",
     "latitude": "51.543836",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097929",
     "latitude": "51.521810",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097929",
     "latitude": "51.521810",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086976",
     "latitude": "51.519015",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.086976",
     "latitude": "51.519015",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.104503",
     "latitude": "51.508257",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.087769",
     "latitude": "51.504550",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.021672",
     "latitude": "51.540494",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.023195",
     "latitude": "51.532957",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076747",
     "latitude": "51.517184",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076437",
     "latitude": "51.519050",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076747",
     "latitude": "51.517184",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076199",
     "latitude": "51.516834",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.078591",
     "latitude": "51.520290",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.077601",
     "latitude": "51.518799",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.059878",
     "latitude": "51.518660",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073180",
     "latitude": "51.513915",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073849",
     "latitude": "51.514457",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.029075",
     "latitude": "51.510647",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.076031",
     "latitude": "51.509547",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.073850",
     "latitude": "51.509313",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111974",
     "latitude": "51.513683",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "-0.111974",
     "latitude": "51.513683",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-01",
+    "yearMonth": "2020-01",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/data/2020_02_london.json
+++ b/web-app/src/main/webapp/data/2020_02_london.json
@@ -1,4578 +1,4578 @@
 [
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111962",
     "latitude": "51.518494",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111962",
     "latitude": "51.518494",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.123317",
     "latitude": "51.515412",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098023",
     "latitude": "51.519905",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098062",
     "latitude": "51.517577",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098062",
     "latitude": "51.517577",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098062",
     "latitude": "51.517577",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097736",
     "latitude": "51.520206",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093948",
     "latitude": "51.518077",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094115",
     "latitude": "51.516497",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094582",
     "latitude": "51.517376",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089596",
     "latitude": "51.518743",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091440",
     "latitude": "51.519807",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094033",
     "latitude": "51.520875",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095381",
     "latitude": "51.521391",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095381",
     "latitude": "51.521391",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075508",
     "latitude": "51.514763",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074115",
     "latitude": "51.511224",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077451",
     "latitude": "51.515523",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077224",
     "latitude": "51.516122",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077080",
     "latitude": "51.514069",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.073065",
     "latitude": "51.511180",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077513",
     "latitude": "51.515075",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077392",
     "latitude": "51.516233",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077224",
     "latitude": "51.516122",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079607",
     "latitude": "51.515657",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077513",
     "latitude": "51.515075",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.075844",
     "latitude": "51.511594",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090804",
     "latitude": "51.511560",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080665",
     "latitude": "51.509344",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078307",
     "latitude": "51.513676",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088473",
     "latitude": "51.518374",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095346",
     "latitude": "51.514970",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080665",
     "latitude": "51.509344",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096846",
     "latitude": "51.511478",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092296",
     "latitude": "51.511386",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090847",
     "latitude": "51.511237",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094197",
     "latitude": "51.510734",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078994",
     "latitude": "51.514137",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077649",
     "latitude": "51.512181",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083618",
     "latitude": "51.517288",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079674",
     "latitude": "51.514409",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079162",
     "latitude": "51.514940",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087549",
     "latitude": "51.514276",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100822",
     "latitude": "51.511165",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080665",
     "latitude": "51.509344",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091506",
     "latitude": "51.513037",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080573",
     "latitude": "51.516006",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091506",
     "latitude": "51.513037",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081938",
     "latitude": "51.513007",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077655",
     "latitude": "51.514088",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089475",
     "latitude": "51.513355",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087670",
     "latitude": "51.516877",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087670",
     "latitude": "51.516877",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078488",
     "latitude": "51.517923",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102647",
     "latitude": "51.513721",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077300",
     "latitude": "51.512607",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091108",
     "latitude": "51.511529",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088473",
     "latitude": "51.518374",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090847",
     "latitude": "51.511237",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083417",
     "latitude": "51.513148",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096643",
     "latitude": "51.512545",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091151",
     "latitude": "51.514992",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078488",
     "latitude": "51.517923",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101959",
     "latitude": "51.513297",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088225",
     "latitude": "51.514656",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085355",
     "latitude": "51.510563",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088233",
     "latitude": "51.515484",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078307",
     "latitude": "51.513676",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077637",
     "latitude": "51.511453",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083618",
     "latitude": "51.517288",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091823",
     "latitude": "51.514418",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086550",
     "latitude": "51.512651",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087666",
     "latitude": "51.511122",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078308",
     "latitude": "51.518091",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086701",
     "latitude": "51.510774",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101274",
     "latitude": "51.512791",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100748",
     "latitude": "51.515031",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093215",
     "latitude": "51.510421",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083645",
     "latitude": "51.512504",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086551",
     "latitude": "51.511616",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092380",
     "latitude": "51.513510",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091108",
     "latitude": "51.511529",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090203",
     "latitude": "51.511118",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081281",
     "latitude": "51.512528",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088843",
     "latitude": "51.509532",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083645",
     "latitude": "51.512504",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.099716",
     "latitude": "51.511435",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086624",
     "latitude": "51.511923",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089716",
     "latitude": "51.514501",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089090",
     "latitude": "51.513258",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086624",
     "latitude": "51.511923",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091151",
     "latitude": "51.514992",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089090",
     "latitude": "51.513258",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078307",
     "latitude": "51.513676",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093791",
     "latitude": "51.509414",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079674",
     "latitude": "51.514409",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077935",
     "latitude": "51.514281",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082058",
     "latitude": "51.509466",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076853",
     "latitude": "51.511916",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094933",
     "latitude": "51.513129",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100974",
     "latitude": "51.514450",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076853",
     "latitude": "51.511916",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104973",
     "latitude": "51.512887",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108164",
     "latitude": "51.516571",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105157",
     "latitude": "51.513330",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.107793",
     "latitude": "51.515450",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104500",
     "latitude": "51.511449",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098148",
     "latitude": "51.517938",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105157",
     "latitude": "51.513330",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102812",
     "latitude": "51.517042",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104973",
     "latitude": "51.512887",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106357",
     "latitude": "51.512549",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098500",
     "latitude": "51.519526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098886",
     "latitude": "51.519254",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.107793",
     "latitude": "51.515450",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104300",
     "latitude": "51.511761",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097962",
     "latitude": "51.519635",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108018",
     "latitude": "51.511749",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.103280",
     "latitude": "51.514109",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102812",
     "latitude": "51.517042",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.098320",
     "latitude": "51.519344",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.107148",
     "latitude": "51.511879",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.110471",
     "latitude": "51.517265",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111132",
     "latitude": "51.512420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111132",
     "latitude": "51.512420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.105561",
     "latitude": "51.510873",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104973",
     "latitude": "51.512887",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101320",
     "latitude": "51.519302",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.104973",
     "latitude": "51.512887",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.102794",
     "latitude": "51.515037",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.101649",
     "latitude": "51.519703",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.088440",
     "latitude": "51.519507",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.096315",
     "latitude": "51.508313",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.076437",
     "latitude": "51.519050",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.077601",
     "latitude": "51.518799",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111974",
     "latitude": "51.513683",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.111974",
     "latitude": "51.513683",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.121813",
     "latitude": "51.507133",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.121813",
     "latitude": "51.507133",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "-0.121813",
     "latitude": "51.507133",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-02",
+    "yearMonth": "2020-02",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/data/2020_03_london.json
+++ b/web-app/src/main/webapp/data/2020_03_london.json
@@ -1,3630 +1,3630 @@
 [
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.112422",
     "latitude": "51.515381",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111962",
     "latitude": "51.518494",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.113256",
     "latitude": "51.516824",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111497",
     "latitude": "51.518226",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095892",
     "latitude": "51.516391",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095960",
     "latitude": "51.517534",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093057",
     "latitude": "51.520085",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093948",
     "latitude": "51.518077",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093969",
     "latitude": "51.519300",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089596",
     "latitude": "51.518743",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088621",
     "latitude": "51.518619",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092723",
     "latitude": "51.517032",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096114",
     "latitude": "51.520747",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094468",
     "latitude": "51.521853",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094033",
     "latitude": "51.520875",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095377",
     "latitude": "51.520789",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094033",
     "latitude": "51.520875",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074613",
     "latitude": "51.512060",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075196",
     "latitude": "51.512609",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075389",
     "latitude": "51.511775",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074613",
     "latitude": "51.512060",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076080",
     "latitude": "51.511445",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074613",
     "latitude": "51.512060",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079607",
     "latitude": "51.515657",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079607",
     "latitude": "51.515657",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074613",
     "latitude": "51.512060",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076592",
     "latitude": "51.514367",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076592",
     "latitude": "51.514367",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078307",
     "latitude": "51.513676",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088995",
     "latitude": "51.512088",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088473",
     "latitude": "51.518374",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079162",
     "latitude": "51.514940",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104001",
     "latitude": "51.513051",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104275",
     "latitude": "51.511661",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082209",
     "latitude": "51.509639",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081832",
     "latitude": "51.514507",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.095037",
     "latitude": "51.510621",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086051",
     "latitude": "51.513569",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084723",
     "latitude": "51.514986",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087666",
     "latitude": "51.511122",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080728",
     "latitude": "51.511611",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084566",
     "latitude": "51.517690",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091506",
     "latitude": "51.513037",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088393",
     "latitude": "51.511332",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086624",
     "latitude": "51.511923",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092625",
     "latitude": "51.513865",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087153",
     "latitude": "51.518910",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094206",
     "latitude": "51.511210",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092268",
     "latitude": "51.514461",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076853",
     "latitude": "51.511916",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076853",
     "latitude": "51.511916",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088042",
     "latitude": "51.511794",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092268",
     "latitude": "51.514461",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093465",
     "latitude": "51.514463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078665",
     "latitude": "51.509950",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079613",
     "latitude": "51.517231",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093257",
     "latitude": "51.513920",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081070",
     "latitude": "51.512390",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091258",
     "latitude": "51.514157",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.077637",
     "latitude": "51.511453",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096846",
     "latitude": "51.511478",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096846",
     "latitude": "51.511478",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088233",
     "latitude": "51.515484",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087666",
     "latitude": "51.511122",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088225",
     "latitude": "51.514656",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083150",
     "latitude": "51.510913",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080146",
     "latitude": "51.514848",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086701",
     "latitude": "51.510774",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097973",
     "latitude": "51.512108",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101055",
     "latitude": "51.513552",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096846",
     "latitude": "51.511478",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094482",
     "latitude": "51.512888",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093796",
     "latitude": "51.512391",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091151",
     "latitude": "51.514992",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.090203",
     "latitude": "51.511118",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092321",
     "latitude": "51.513194",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.077777",
     "latitude": "51.518046",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093796",
     "latitude": "51.512391",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078924",
     "latitude": "51.508587",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088013",
     "latitude": "51.519365",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089218",
     "latitude": "51.516057",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084201",
     "latitude": "51.510949",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.093398",
     "latitude": "51.512951",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086728",
     "latitude": "51.510477",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086701",
     "latitude": "51.510774",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088225",
     "latitude": "51.514656",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080665",
     "latitude": "51.509344",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085257",
     "latitude": "51.511200",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101073",
     "latitude": "51.513453",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082512",
     "latitude": "51.512387",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089582",
     "latitude": "51.511495",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084768",
     "latitude": "51.512882",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080244",
     "latitude": "51.511828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082571",
     "latitude": "51.514753",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089698",
     "latitude": "51.511812",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100202",
     "latitude": "51.513268",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.098777",
     "latitude": "51.512526",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096561",
     "latitude": "51.514513",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085310",
     "latitude": "51.518511",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080952",
     "latitude": "51.514528",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082458",
     "latitude": "51.517431",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096075",
     "latitude": "51.514766",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087780",
     "latitude": "51.508066",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.096900",
     "latitude": "51.510868",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086550",
     "latitude": "51.512651",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092865",
     "latitude": "51.510182",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078488",
     "latitude": "51.517923",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088995",
     "latitude": "51.512088",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080728",
     "latitude": "51.511611",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082527",
     "latitude": "51.512027",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091494",
     "latitude": "51.510924",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094933",
     "latitude": "51.513129",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092719",
     "latitude": "51.512652",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091151",
     "latitude": "51.514992",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083972",
     "latitude": "51.510549",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080234",
     "latitude": "51.516855",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092040",
     "latitude": "51.515087",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084284",
     "latitude": "51.510671",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080952",
     "latitude": "51.514528",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084199",
     "latitude": "51.513394",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.090506",
     "latitude": "51.513524",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.089647",
     "latitude": "51.513384",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081091",
     "latitude": "51.516014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.082527",
     "latitude": "51.512027",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.083695",
     "latitude": "51.512352",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088075",
     "latitude": "51.512388",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104244",
     "latitude": "51.512749",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.107672",
     "latitude": "51.517678",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111242",
     "latitude": "51.516738",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108018",
     "latitude": "51.511749",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.106922",
     "latitude": "51.514204",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104442",
     "latitude": "51.511466",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104973",
     "latitude": "51.512887",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.107672",
     "latitude": "51.517678",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.099818",
     "latitude": "51.519017",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104281",
     "latitude": "51.516032",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101794",
     "latitude": "51.516207",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.107485",
     "latitude": "51.516614",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.110735",
     "latitude": "51.517836",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101794",
     "latitude": "51.516207",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101963",
     "latitude": "51.519097",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.109647",
     "latitude": "51.514887",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101794",
     "latitude": "51.516207",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101320",
     "latitude": "51.519302",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.109826",
     "latitude": "51.516814",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102502",
     "latitude": "51.516165",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.106214",
     "latitude": "51.513905",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108965",
     "latitude": "51.516386",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104909",
     "latitude": "51.517912",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.108175",
     "latitude": "51.512830",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102380",
     "latitude": "51.517728",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101963",
     "latitude": "51.519097",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.103280",
     "latitude": "51.514109",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111132",
     "latitude": "51.512420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.111132",
     "latitude": "51.512420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.075841",
     "latitude": "51.523977",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.086655",
     "latitude": "51.519783",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.091732",
     "latitude": "51.521080",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.076686",
     "latitude": "51.517588",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.077601",
     "latitude": "51.518799",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.071371",
     "latitude": "51.516494",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.073849",
     "latitude": "51.514457",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.073850",
     "latitude": "51.509313",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.079130",
     "latitude": "51.507808",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.073078",
     "latitude": "51.508824",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "-0.124406",
     "latitude": "51.513100",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-03",
+    "yearMonth": "2020-03",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/data/2020_04_london.json
+++ b/web-app/src/main/webapp/data/2020_04_london.json
@@ -1,1416 +1,1416 @@
 [
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097053",
     "latitude": "51.518262",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095914",
     "latitude": "51.520348",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091649",
     "latitude": "51.518938",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094115",
     "latitude": "51.516497",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.092297",
     "latitude": "51.518949",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095381",
     "latitude": "51.521391",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.075146",
     "latitude": "51.513435",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074613",
     "latitude": "51.512060",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.078806",
     "latitude": "51.516193",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.078250",
     "latitude": "51.515033",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076095",
     "latitude": "51.512462",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076113",
     "latitude": "51.511014",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.077224",
     "latitude": "51.516122",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.077224",
     "latitude": "51.516122",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.075722",
     "latitude": "51.511053",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076592",
     "latitude": "51.514367",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.077451",
     "latitude": "51.515523",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073152",
     "latitude": "51.512206",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076853",
     "latitude": "51.511916",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.084095",
     "latitude": "51.516900",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082811",
     "latitude": "51.510054",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079011",
     "latitude": "51.509614",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080034",
     "latitude": "51.513389",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082628",
     "latitude": "51.518189",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.086166",
     "latitude": "51.510828",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080318",
     "latitude": "51.520678",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.078749",
     "latitude": "51.520985",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097645",
     "latitude": "51.515142",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.085014",
     "latitude": "51.509775",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079444",
     "latitude": "51.512678",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094464",
     "latitude": "51.512959",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079674",
     "latitude": "51.514409",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.088225",
     "latitude": "51.514656",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.096511",
     "latitude": "51.511922",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082913",
     "latitude": "51.513463",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.084701",
     "latitude": "51.509320",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.078127",
     "latitude": "51.512135",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.083755",
     "latitude": "51.514358",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082527",
     "latitude": "51.512027",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.095015",
     "latitude": "51.513220",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.086175",
     "latitude": "51.510945",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.084618",
     "latitude": "51.512682",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.087118",
     "latitude": "51.513199",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089364",
     "latitude": "51.515331",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.096363",
     "latitude": "51.513377",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.086764",
     "latitude": "51.510307",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089435",
     "latitude": "51.511223",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094628",
     "latitude": "51.514203",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.096814",
     "latitude": "51.512952",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080728",
     "latitude": "51.511611",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.087760",
     "latitude": "51.517149",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.091084",
     "latitude": "51.513830",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081516",
     "latitude": "51.510014",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.083587",
     "latitude": "51.512171",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.089465",
     "latitude": "51.510855",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.082571",
     "latitude": "51.514753",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104494",
     "latitude": "51.509848",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.098320",
     "latitude": "51.519344",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104134",
     "latitude": "51.514699",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.101963",
     "latitude": "51.519097",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.103280",
     "latitude": "51.514109",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102721",
     "latitude": "51.515404",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102794",
     "latitude": "51.515037",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.112519",
     "latitude": "51.517568",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102930",
     "latitude": "51.518375",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.098138",
     "latitude": "51.520609",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097929",
     "latitude": "51.521810",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097929",
     "latitude": "51.521810",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097210",
     "latitude": "51.523156",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.097929",
     "latitude": "51.521810",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.094959",
     "latitude": "51.522868",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.070333",
     "latitude": "51.530820",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.076747",
     "latitude": "51.517184",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.075411",
     "latitude": "51.516047",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073849",
     "latitude": "51.514457",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073849",
     "latitude": "51.514457",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "-0.073850",
     "latitude": "51.509313",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-04",
+    "yearMonth": "2020-04",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/data/2020_05_london.json
+++ b/web-app/src/main/webapp/data/2020_05_london.json
@@ -1,1356 +1,1356 @@
 [
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.111962",
     "latitude": "51.518494",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095914",
     "latitude": "51.520348",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097334",
     "latitude": "51.521567",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097277",
     "latitude": "51.515307",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097601",
     "latitude": "51.520699",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.098572",
     "latitude": "51.516767",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.098642",
     "latitude": "51.517146",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095892",
     "latitude": "51.516391",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097562",
     "latitude": "51.518864",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.090348",
     "latitude": "51.519358",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094582",
     "latitude": "51.517376",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092628",
     "latitude": "51.517920",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094094",
     "latitude": "51.515606",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094546",
     "latitude": "51.520658",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.093933",
     "latitude": "51.519812",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092517",
     "latitude": "51.520580",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.091649",
     "latitude": "51.518938",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094115",
     "latitude": "51.516497",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.093057",
     "latitude": "51.520085",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.096114",
     "latitude": "51.520747",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.096114",
     "latitude": "51.520747",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095860",
     "latitude": "51.521660",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095381",
     "latitude": "51.521391",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094033",
     "latitude": "51.520875",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095381",
     "latitude": "51.521391",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077596",
     "latitude": "51.515849",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074958",
     "latitude": "51.514151",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074330",
     "latitude": "51.513647",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076270",
     "latitude": "51.515504",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074793",
     "latitude": "51.511208",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076044",
     "latitude": "51.512650",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078393",
     "latitude": "51.515728",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074210",
     "latitude": "51.511711",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077451",
     "latitude": "51.515523",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076459",
     "latitude": "51.513061",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076435",
     "latitude": "51.513627",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.076080",
     "latitude": "51.511445",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.073254",
     "latitude": "51.512856",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077224",
     "latitude": "51.516122",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074115",
     "latitude": "51.511224",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077578",
     "latitude": "51.510795",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081540",
     "latitude": "51.510806",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.090710",
     "latitude": "51.513132",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083086",
     "latitude": "51.511407",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092926",
     "latitude": "51.511477",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079195",
     "latitude": "51.513798",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.100179",
     "latitude": "51.514158",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078488",
     "latitude": "51.517923",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077029",
     "latitude": "51.510148",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.096385",
     "latitude": "51.510787",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101395",
     "latitude": "51.510913",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.097699",
     "latitude": "51.511420",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078994",
     "latitude": "51.514137",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081580",
     "latitude": "51.520510",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094206",
     "latitude": "51.511210",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080322",
     "latitude": "51.510651",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.085149",
     "latitude": "51.517196",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084566",
     "latitude": "51.517690",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.096659",
     "latitude": "51.511133",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088233",
     "latitude": "51.515484",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084621",
     "latitude": "51.510200",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.086272",
     "latitude": "51.513114",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079283",
     "latitude": "51.511021",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.095037",
     "latitude": "51.510621",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079875",
     "latitude": "51.510995",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.099907",
     "latitude": "51.512031",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.082571",
     "latitude": "51.514753",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084967",
     "latitude": "51.512598",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.077694",
     "latitude": "51.513171",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.082965",
     "latitude": "51.516351",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088233",
     "latitude": "51.515484",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088203",
     "latitude": "51.518262",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.085833",
     "latitude": "51.513952",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.089451",
     "latitude": "51.517032",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101274",
     "latitude": "51.512791",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088241",
     "latitude": "51.510835",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079287",
     "latitude": "51.511956",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079398",
     "latitude": "51.516508",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.087086",
     "latitude": "51.512596",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.086278",
     "latitude": "51.509876",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078856",
     "latitude": "51.518433",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084980",
     "latitude": "51.516078",
     "crimeType": "Possession of weapons"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080782",
     "latitude": "51.514804",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.087549",
     "latitude": "51.514276",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083993",
     "latitude": "51.511440",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079448",
     "latitude": "51.511554",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080376",
     "latitude": "51.517244",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080244",
     "latitude": "51.511828",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084983",
     "latitude": "51.510494",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.091720",
     "latitude": "51.513454",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.094720",
     "latitude": "51.514420",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.091823",
     "latitude": "51.514418",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083296",
     "latitude": "51.517058",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081549",
     "latitude": "51.511625",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092077",
     "latitude": "51.512147",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.084251",
     "latitude": "51.520059",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101452",
     "latitude": "51.512650",
     "crimeType": "Vehicle crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.078484",
     "latitude": "51.517680",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.085669",
     "latitude": "51.515100",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088872",
     "latitude": "51.510890",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.080244",
     "latitude": "51.511828",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.079786",
     "latitude": "51.517576",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.083386",
     "latitude": "51.509757",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.100632",
     "latitude": "51.515739",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.093493",
     "latitude": "51.513447",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.081620",
     "latitude": "51.516814",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.106680",
     "latitude": "51.515882",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.112939",
     "latitude": "51.518231",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.110735",
     "latitude": "51.517836",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.104621",
     "latitude": "51.512692",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.111181",
     "latitude": "51.516476",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108453",
     "latitude": "51.515173",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Burglary"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108231",
     "latitude": "51.513928",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.101345",
     "latitude": "51.518709",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105561",
     "latitude": "51.510873",
     "crimeType": "Other theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.102741",
     "latitude": "51.513885",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105561",
     "latitude": "51.510873",
     "crimeType": "Robbery"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.108283",
     "latitude": "51.517526",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Shoplifting"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.110710",
     "latitude": "51.513914",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105900",
     "latitude": "51.516966",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.109709",
     "latitude": "51.517909",
     "crimeType": "Theft from the person"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.104887",
     "latitude": "51.516347",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.104252",
     "latitude": "51.516733",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.107672",
     "latitude": "51.517678",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.105134",
     "latitude": "51.513869",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.100884",
     "latitude": "51.516966",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.102721",
     "latitude": "51.515404",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.092178",
     "latitude": "51.570070",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.103597",
     "latitude": "51.519312",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.102506",
     "latitude": "51.519888",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Criminal damage and arson"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.088766",
     "latitude": "51.519620",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.064566",
     "latitude": "51.528440",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.043454",
     "latitude": "51.510069",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "-0.074901",
     "latitude": "51.506255",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Anti-social behaviour"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Bicycle theft"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Drugs"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Public order"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Violence and sexual offences"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"
   },
   {
-    "month": "2020-05",
+    "yearMonth": "2020-05",
     "longitude": "",
     "latitude": "",
     "crimeType": "Other crime"

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -59,7 +59,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="radio" id="four-weeks" name="time-frame"
+          <input type="radio" class="time-frame" id="four-weeks" name="time-frame"
             value="four-weeks">
         </div>
         <div class="ten columns">
@@ -68,7 +68,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="radio" id="three-months" name="time-frame"
+          <input type="radio" class="time-frame" id="three-months" name="time-frame"
             value="three-months">
         </div>
         <div class="ten columns">
@@ -77,7 +77,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="radio" id="six-months" name="time-frame"
+          <input type="radio" class="time-frame" id="six-months" name="time-frame"
             value="six-months">
         </div>
         <div class="ten columns">
@@ -86,7 +86,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="radio" id="twelve-months" name="time-frame"
+          <input type="radio" class="time-frame" id="twelve-months" name="time-frame"
             value="twelve-months" checked="checked">
         </div>
         <div class="ten columns">
@@ -95,7 +95,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="radio" id="custom-radio" name="time-frame"
+          <input type="radio" class="time-frame" id="custom-radio" name="time-frame"
             value="custom">
         </div>
         <div class="ten columns">

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -123,7 +123,7 @@
             value="p-one" checked="checked">
         </div>
         <div class="ten columns">
-          <label for="p-one">Placeholder 1</label>
+          <label for="p-one">Drugs</label>
         </div>
       </div>
       <div class="row">
@@ -132,7 +132,7 @@
             value="p-two" checked="checked">
         </div>
         <div class="ten columns">
-          <label for="p-two">Placeholder 2</label>
+          <label for="p-two">Burglary</label>
         </div>
       </div>
       <div class="row">
@@ -141,7 +141,7 @@
             value="p-three" checked="checked">
         </div>
         <div class="ten columns">
-          <label for="p-three">Placeholder 3</label>
+          <label for="p-three">Criminal damage and arson</label>
         </div>
       </div>
       <div class="row">
@@ -150,7 +150,7 @@
             value="p-four" checked="checked">
         </div>
         <div class="ten columns">
-          <label for="p-four">Placeholder 4</label>
+          <label for="p-four">Theft</label>
         </div>
       </div>
       <button id="select-all-cats" class="menu-button">Select all</button>

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -57,148 +57,152 @@
       <div class="row menu-subheading">
         <h2>Time Frame</h2>
       </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="radio" class="time-frame" id="four-weeks" name="time-frame"
-            value="1">
+      <div id="time-frame-options">
+        <div class="row">
+          <div class="two columns right">
+            <input type="radio" class="time-frame" id="four-weeks" name="time-frame"
+              value="1">
+          </div>
+          <div class="ten columns">
+            <label for="four-weeks">Last 4 weeks</label>
+          </div>
         </div>
-        <div class="ten columns">
-          <label for="four-weeks">Last 4 weeks</label>
+        <div class="row">
+          <div class="two columns right">
+            <input type="radio" class="time-frame" id="three-months" name="time-frame"
+              value="3">
+          </div>
+          <div class="ten columns">
+            <label for="three-months">Last 3 months</label>
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="radio" class="time-frame" id="three-months" name="time-frame"
-            value="3">
+        <div class="row">
+          <div class="two columns right">
+            <input type="radio" class="time-frame" id="six-months" name="time-frame"
+              value="6" checked>
+          </div>
+          <div class="ten columns">
+            <label for="six-months">Last 6 months</label>
+          </div>
         </div>
-        <div class="ten columns">
-          <label for="three-months">Last 3 months</label>
+        <div class="row">
+          <div class="two columns right">
+            <input type="radio" class="time-frame" id="twelve-months" name="time-frame"
+              value="12">
+          </div>
+          <div class="ten columns">
+            <label for="twelve-months">Last 12 months</label>
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="radio" class="time-frame" id="six-months" name="time-frame"
-            value="6" checked>
+        <div class="row">
+          <div class="two columns right">
+            <input type="radio" class="time-frame" id="custom-radio" name="time-frame"
+              value="custom">
+          </div>
+          <div class="ten columns">
+            <label for="custom-radio">Custom:</label>
+          </div>
         </div>
-        <div class="ten columns">
-          <label for="six-months">Last 6 months</label>
+        <div class="row last-row">
+          <div class="six columns right desc">
+            Last
+          </div>
+          <div class="three columns">
+            <input type="number" id="custom-interval" name="custom-interval">
+          </div>
+          <div class="three columns desc">
+            months
+          </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="radio" class="time-frame" id="twelve-months" name="time-frame"
-            value="12">
-        </div>
-        <div class="ten columns">
-          <label for="twelve-months">Last 12 months</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="radio" class="time-frame" id="custom-radio" name="time-frame"
-            value="custom">
-        </div>
-        <div class="ten columns">
-          <label for="custom-radio">Custom:</label>
-        </div>
-      </div>
-      <div class="row last-row">
-        <div class="six columns right desc">
-          Last
-        </div>
-        <div class="three columns">
-          <input type="number" id="custom-interval" name="custom-interval">
-        </div>
-        <div class="three columns desc">
-          months
-        </div>
-      </div>
+      <div>
       <!-- Category -->
       <div class="row menu-subheading">
         <h2>Category</h2>
       </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-one" name="category"
-            value="drugs" checked="checked">
+      <div id="category-options">
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-one" name="category"
+              value="drugs" checked="checked">
+          </div>
+          <div class="ten columns">
+            <label for="p-one">Drugs</label>
+          </div>
         </div>
-        <div class="ten columns">
-          <label for="p-one">Drugs</label>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-two" name="category"
+              value="burglary" checked="checked">
+          </div>
+          <div class="ten columns">
+            <label for="p-two">Burglary</label>
+          </div>
         </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-three" name="category"
+              value="arson" checked="checked">
+          </div>
+          <div class="ten columns">
+            <label for="p-three">Criminal damage and arson</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-four" name="category"
+              value="theft">
+          </div>
+          <div class="ten columns">
+            <label for="p-four">Theft</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-five" name="category"
+              value="weapons">
+          </div>
+          <div class="ten columns">
+            <label for="p-five">Possesion of weapons</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-six" name="category"
+              value="violence">
+          </div>
+          <div class="ten columns">
+            <label for="p-six">Violence and sexual offences</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-seven" name="category"
+              value="order">
+          </div>
+          <div class="ten columns">
+            <label for="p-seven">Public order</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-eight" name="category"
+              value="anti-social">
+          </div>
+          <div class="ten columns">
+            <label for="p-eight">Anti-social behaviour</label>
+          </div>
+        </div>
+        <div class="row">
+          <div class="two columns right">
+            <input type="checkbox" class="category" id="p-nine" name="category"
+              value="other crime">
+          </div>
+          <div class="ten columns">
+            <label for="p-nine">Other crime</label>
+          </div>
+        </div>
+        <button id="select-all-cats" class="menu-button">Select all</button>
       </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-two" name="category"
-            value="burglary" checked="checked">
-        </div>
-        <div class="ten columns">
-          <label for="p-two">Burglary</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-three" name="category"
-            value="arson" checked="checked">
-        </div>
-        <div class="ten columns">
-          <label for="p-three">Criminal damage and arson</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
-            value="theft">
-        </div>
-        <div class="ten columns">
-          <label for="p-four">Theft</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-five" name="category"
-            value="weapons">
-        </div>
-        <div class="ten columns">
-          <label for="p-five">Possesion of weapons</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-six" name="category"
-            value="violence">
-        </div>
-        <div class="ten columns">
-          <label for="p-six">Violence and sexual offences</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-seven" name="category"
-            value="order">
-        </div>
-        <div class="ten columns">
-          <label for="p-seven">Public order</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-eight" name="category"
-            value="anti-social">
-        </div>
-        <div class="ten columns">
-          <label for="p-eight">Anti-social behaviour</label>
-        </div>
-      </div>
-      <div class="row">
-        <div class="two columns right">
-          <input type="checkbox" class="category" id="p-nine" name="category"
-            value="other crime">
-        </div>
-        <div class="ten columns">
-          <label for="p-nine">Other crime</label>
-        </div>
-      </div>
-      <button id="select-all-cats" class="menu-button">Select all</button>
       <!-- Time of day -->
       <div class="row menu-subheading">
         <h2>Time of Day</h2>

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -78,7 +78,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="six-months" name="time-frame"
-            value="6">
+            value="6" checked>
         </div>
         <div class="ten columns">
           <label for="six-months">Last 6 months</label>
@@ -87,7 +87,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="twelve-months" name="time-frame"
-            value="12" checked="checked">
+            value="12">
         </div>
         <div class="ten columns">
           <label for="twelve-months">Last 12 months</label>
@@ -120,7 +120,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="checkbox" class="category" id="p-one" name="category"
-            value="p-one" checked="checked">
+            value="drugs" checked="checked">
         </div>
         <div class="ten columns">
           <label for="p-one">Drugs</label>
@@ -129,7 +129,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="checkbox" class="category" id="p-two" name="category"
-            value="p-two" checked="checked">
+            value="burglary" checked="checked">
         </div>
         <div class="ten columns">
           <label for="p-two">Burglary</label>
@@ -138,7 +138,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="checkbox" class="category" id="p-three" name="category"
-            value="p-three" checked="checked">
+            value="arson" checked="checked">
         </div>
         <div class="ten columns">
           <label for="p-three">Criminal damage and arson</label>
@@ -147,7 +147,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="checkbox" class="category" id="p-four" name="category"
-            value="p-four" checked="checked">
+            value="theft">
         </div>
         <div class="ten columns">
           <label for="p-four">Theft</label>

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -119,7 +119,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" id="p-one" name="category"
+          <input type="checkbox" class="category" id="p-one" name="category"
             value="p-one" checked="checked">
         </div>
         <div class="ten columns">
@@ -128,7 +128,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" id="p-two" name="category"
+          <input type="checkbox" class="category" id="p-two" name="category"
             value="p-two" checked="checked">
         </div>
         <div class="ten columns">
@@ -137,7 +137,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" id="p-three" name="category"
+          <input type="checkbox" class="category" id="p-three" name="category"
             value="p-three" checked="checked">
         </div>
         <div class="ten columns">
@@ -146,7 +146,7 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-four" name="category"
             value="p-four" checked="checked">
         </div>
         <div class="ten columns">

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -153,6 +153,51 @@
           <label for="p-four">Theft</label>
         </div>
       </div>
+      <div class="row">
+        <div class="two columns right">
+          <input type="checkbox" class="category" id="p-four" name="category"
+            value="weapons">
+        </div>
+        <div class="ten columns">
+          <label for="p-four">Possesion of weapons</label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="two columns right">
+          <input type="checkbox" class="category" id="p-four" name="category"
+            value="violence">
+        </div>
+        <div class="ten columns">
+          <label for="p-four">Violence and sexual offences</label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="two columns right">
+          <input type="checkbox" class="category" id="p-four" name="category"
+            value="order">
+        </div>
+        <div class="ten columns">
+          <label for="p-four">Public order</label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="two columns right">
+          <input type="checkbox" class="category" id="p-four" name="category"
+            value="anti-social">
+        </div>
+        <div class="ten columns">
+          <label for="p-four">Anti-social behaviour</label>
+        </div>
+      </div>
+      <div class="row">
+        <div class="two columns right">
+          <input type="checkbox" class="category" id="p-four" name="category"
+            value="other crime">
+        </div>
+        <div class="ten columns">
+          <label for="p-four">Other crime</label>
+        </div>
+      </div>
       <button id="select-all-cats" class="menu-button">Select all</button>
       <!-- Time of day -->
       <div class="row menu-subheading">

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -155,47 +155,47 @@
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-five" name="category"
             value="weapons">
         </div>
         <div class="ten columns">
-          <label for="p-four">Possesion of weapons</label>
+          <label for="p-five">Possesion of weapons</label>
         </div>
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-six" name="category"
             value="violence">
         </div>
         <div class="ten columns">
-          <label for="p-four">Violence and sexual offences</label>
+          <label for="p-six">Violence and sexual offences</label>
         </div>
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-seven" name="category"
             value="order">
         </div>
         <div class="ten columns">
-          <label for="p-four">Public order</label>
+          <label for="p-seven">Public order</label>
         </div>
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-eight" name="category"
             value="anti-social">
         </div>
         <div class="ten columns">
-          <label for="p-four">Anti-social behaviour</label>
+          <label for="p-eight">Anti-social behaviour</label>
         </div>
       </div>
       <div class="row">
         <div class="two columns right">
-          <input type="checkbox" class="category" id="p-four" name="category"
+          <input type="checkbox" class="category" id="p-nine" name="category"
             value="other crime">
         </div>
         <div class="ten columns">
-          <label for="p-four">Other crime</label>
+          <label for="p-nine">Other crime</label>
         </div>
       </div>
       <button id="select-all-cats" class="menu-button">Select all</button>

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -60,7 +60,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="four-weeks" name="time-frame"
-            value="four-weeks">
+            value="1">
         </div>
         <div class="ten columns">
           <label for="four-weeks">Last 4 weeks</label>
@@ -69,7 +69,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="three-months" name="time-frame"
-            value="three-months">
+            value="3">
         </div>
         <div class="ten columns">
           <label for="three-months">Last 3 months</label>
@@ -78,7 +78,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="six-months" name="time-frame"
-            value="six-months">
+            value="6">
         </div>
         <div class="ten columns">
           <label for="six-months">Last 6 months</label>
@@ -87,7 +87,7 @@
       <div class="row">
         <div class="two columns right">
           <input type="radio" class="time-frame" id="twelve-months" name="time-frame"
-            value="twelve-months" checked="checked">
+            value="12" checked="checked">
         </div>
         <div class="ten columns">
           <label for="twelve-months">Last 12 months</label>

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -62,10 +62,10 @@ window.onload = () => {
   document.getElementById('form-container').style.display = 'none';
   document.getElementById('report-button').addEventListener('click', showReportForm);
   const map = initMap();
-  const categories = Array.from(document.getElementsByClassName('category'));
-  const timeFrames = Array.from(document.getElementsByClassName('time-frame'));
-  categories.map(categoryElement => categoryElement.addEventListener('change', () => { loadPoliceReports(map) }));
-  timeFrames.map(timeFrameElement => timeFrameElement.addEventListener('change', () => { loadPoliceReports(map) }));
+  const timeFrameOptions = document.getElementById("time-frame-options");
+  timeFrameOptions.addEventListener('change', () => {loadPoliceReports(map)});
+  const categoryOptions = document.getElementById("category-options");
+  categoryOptions.addEventListener('change', () => {loadPoliceReports(map)});
   loadPoliceReports(map);
   displayUserLocation(map);
 };
@@ -97,7 +97,6 @@ async function createPoliceReportMarkers(map, file_name, uncheckedCategories, nu
   
   if (reports.length != 0 && !isReportwithinTimeFrame(reports[0].month, numberofMonths)) {
     // Only check first report because all reports have same date if in same file
-    console.log("reach here");
     return;
   }
 

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -73,6 +73,9 @@ function showReportForm() {
 async function loadPoliceReports(map) {
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']
   for (const file_name of FILE_NAMES) {
+    if (!withinTimeFrame(file_name)) {
+      continue;
+    }
     const data = await fetch('../data/' + file_name + '.json');
     const reports = await data.json();
     for (report of reports) {
@@ -90,16 +93,20 @@ function filter() {
   const categories = Array.from(document.getElementsByClassName('category'));
   const uncheckedCategories = categories.filter(category => !category.checked);
   const time = document.querySelector("input.time-frame[checked]").value;
-  const month = Number(filename.substring(5, 7));
-  const year = Number(filename.substring(0, 4));
-  console.log(month);
-  const today = new Date();
-  const monthDiff = (today.getFullYear() - year) * 12 + ((today.getMonth() + 1) - month);
-
-
-  console.log(time);
   for (category of categories) {
     console.log(category);
   }
   console.log("Theft".includes("theft"));
+}
+
+function withinTimeFrame(filename) {
+  const userTimeFrame = Number(document.querySelector("input.time-frame[checked]").value);
+  
+  const month = Number(filename.substring(5, 7));
+  const year = Number(filename.substring(0, 4));
+
+  const today = new Date();
+  const monthDiff = (today.getFullYear() - year) * 12 + ((today.getMonth() + 1) - month);
+
+  return (monthDiff < userTimeFrame);
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -95,7 +95,7 @@ async function createPoliceReportMarkers(map, file_name, uncheckedCategories, nu
   const data = await fetch('../data/' + file_name + '.json');
   const reports = await data.json();
 
-  if (reports.length !== 0 && !isReportwithinTimeFrame(reports[0].month, numberOfMonths)) {
+  if (reports.length !== 0 && !isReportwithinTimeFrame(reports[0].yearMonth, numberOfMonths)) {
     // Only check first report because all reports have same date if in same file
     return [];
   }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -63,9 +63,9 @@ window.onload = () => {
   document.getElementById('report-button').addEventListener('click', showReportForm);
   const map = initMap();
   const timeFrameOptions = document.getElementById("time-frame-options");
-  timeFrameOptions.addEventListener('change', () => {loadPoliceReports(map)});
+  timeFrameOptions.addEventListener('change', () => { loadPoliceReports(map) });
   const categoryOptions = document.getElementById("category-options");
-  categoryOptions.addEventListener('change', () => {loadPoliceReports(map)});
+  categoryOptions.addEventListener('change', () => { loadPoliceReports(map) });
   loadPoliceReports(map);
   displayUserLocation(map);
 };
@@ -79,35 +79,35 @@ async function loadPoliceReports(map) {
   for (const marker of mapMarkers) {
     marker.setMap(null);
   }
-  mapMarkers.length = 0;
+  mapMarkers = [];
 
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']
   const uncheckedCategoriesElement = Array.from(document.querySelectorAll("input.category:not(:checked)"));
   const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
-  const numberofMonths = Number(document.querySelector("input.time-frame:checked").value);
+  const numberOfMonths = Number(document.querySelector("input.time-frame:checked").value);
 
   for (const file_name of FILE_NAMES) {
-    createPoliceReportMarkers(map, file_name, uncheckedCategories, numberofMonths);
+    createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths);
   }
 }
 
-async function createPoliceReportMarkers(map, file_name, uncheckedCategories, numberofMonths) {
+async function createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths) {
   const data = await fetch('../data/' + file_name + '.json');
   const reports = await data.json();
-  
-  if (reports.length != 0 && !isReportwithinTimeFrame(reports[0].month, numberofMonths)) {
+
+  if (reports.length !== 0 && !isReportwithinTimeFrame(reports[0].month, numberOfMonths)) {
     // Only check first report because all reports have same date if in same file
     return;
   }
 
-  const filteredReports = reports.filter(report => {
+  const filteredReports = reports.filter((report) => {
     if (!report.latitude || !report.longitude) {
       return false;
     }
     return displayCrimeType(uncheckedCategories, report.crimeType);
   });
 
-  const markers = filteredReports.map(report => new google.maps.Marker({
+  const markers = filteredReports.map((report) => new google.maps.Marker({
     position: {
       lat: Number(report.latitude),
       lng: Number(report.longitude)
@@ -127,12 +127,12 @@ function displayCrimeType(uncheckedCategories, crimeType) {
   return true;
 }
 
-function isReportwithinTimeFrame(reportDate, numberofMonths) {
+function isReportwithinTimeFrame(reportDate, numberOfMonths) {
   const month = Number(reportDate.substring(5, 7));
   const year = Number(reportDate.substring(0, 4));
 
   const today = new Date();
   const monthDiff = (today.getFullYear() - year) * 12 + today.getMonth() + 1 - month;
 
-  return (monthDiff < numberofMonths);
+  return (monthDiff < numberOfMonths);
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -86,9 +86,9 @@ async function loadPoliceReports(map) {
   const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
   const numberOfMonths = Number(document.querySelector("input.time-frame:checked").value);
 
-  for (const file_name of FILE_NAMES) {
-    createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths);
-  }
+  mapMarkers = await Promise.all(FILE_NAMES.map((file_name) =>
+    createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths)));
+  mapMarkers = mapMarkers.flat(); 
 }
 
 async function createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths) {
@@ -97,7 +97,7 @@ async function createPoliceReportMarkers(map, file_name, uncheckedCategories, nu
 
   if (reports.length !== 0 && !isReportwithinTimeFrame(reports[0].month, numberOfMonths)) {
     // Only check first report because all reports have same date if in same file
-    return;
+    return [];
   }
 
   const filteredReports = reports.filter((report) => {
@@ -114,7 +114,7 @@ async function createPoliceReportMarkers(map, file_name, uncheckedCategories, nu
     }, map: map
   }));
 
-  mapMarkers = mapMarkers.concat(markers);
+  return markers;
 }
 
 function displayCrimeType(uncheckedCategories, crimeType) {

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -63,8 +63,8 @@ window.onload = () => {
   const map = initMap();
   const categories = Array.from(document.getElementsByClassName('category'));
   const timeFrames = Array.from(document.getElementsByClassName('time-frame'));
-  categories.map(categoryElement => categoryElement.addEventListener('change', () => {loadPoliceReports(map)}));
-  timeFrames.map(timeFrameElement => timeFrameElement.addEventListener('change', () => {loadPoliceReports(map)}));
+  categories.map(categoryElement => categoryElement.addEventListener('change', () => { loadPoliceReports(map) }));
+  timeFrames.map(timeFrameElement => timeFrameElement.addEventListener('change', () => { loadPoliceReports(map) }));
   loadPoliceReports(map);
   displayUserLocation(map);
 };
@@ -84,18 +84,20 @@ async function loadPoliceReports(map) {
     }
     const data = await fetch('../data/' + file_name + '.json');
     const reports = await data.json();
-    for (report of reports) {
-      if (report.latitude == null || report.longitude == null
-        || displayCrimeType(uncheckedCategories, report.crimeType)) {
-        continue;
+    
+    const filteredReports = reports.filter(report => {
+      if (report.latitude == "" || report.longitude == "") {
+        return false;
       }
-      new google.maps.Marker({
-        position: {
-          lat: Number(report.latitude),
-          lng: Number(report.longitude)
-        }, map: map
-      });
-    };
+      return displayCrimeType(uncheckedCategories, report.crimeType);
+    });
+
+    const markers = filteredReports.map(report => new google.maps.Marker({
+      position: {
+        lat: Number(report.latitude),
+        lng: Number(report.longitude)
+      }, map: map
+    }));
   }
 }
 
@@ -107,12 +109,13 @@ function getCategoriesNotDisplayed() {
 }
 
 function displayCrimeType(uncheckedCategories, crimeType) {
+  // Don't display if category unchecked
   for (category of uncheckedCategories) {
     if (crimeType.toLowerCase().includes(category)) {
-      return true;
+      return false;
     }
   }
-  return false;
+  return true;
 }
 
 function withinTimeFrame(filename) {

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -91,7 +91,7 @@ async function loadPoliceReports(map) {
     const reports = await data.json();
 
     const filteredReports = reports.filter(report => {
-      if (report.latitude == "" || report.longitude == "") {
+      if (!report.latitude || !report.longitude) {
         return false;
       }
       return displayCrimeType(uncheckedCategories, report.crimeType);

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -96,11 +96,11 @@ async function createPoliceReportMarkers(map, file_name, uncheckedCategories, nu
   const reports = await data.json();
 
   const reportsDate = new Date();
+  // Only check first report because all reports have same date if in same file
   reportsDate.setMonth(Number(reports[0].yearMonth.substring(5, 7)));
   reportsDate.setYear(Number(reports[0].yearMonth.substring(0, 4)));
 
   if (reports.length !== 0 && !isReportwithinTimeFrame(reportsDate, numberOfMonths)) {
-    // Only check first report because all reports have same date if in same file
     return [];
   }
 

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -87,8 +87,19 @@ async function loadPoliceReports(map) {
 }
 
 function filter() {
-  const categories = document.getElementsByClassName('category');
+  const categories = Array.from(document.getElementsByClassName('category'));
+  const uncheckedCategories = categories.filter(category => !category.checked);
+  const time = document.querySelector("input.time-frame[checked]").value;
+  const month = Number(filename.substring(5, 7));
+  const year = Number(filename.substring(0, 4));
+  console.log(month);
+  const today = new Date();
+  const monthDiff = (today.getFullYear() - year) * 12 + ((today.getMonth() + 1) - month);
+
+
+  console.log(time);
   for (category of categories) {
-    console.log(category)
+    console.log(category);
   }
+  console.log("Theft".includes("theft"));
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -75,7 +75,9 @@ function showReportForm() {
 
 async function loadPoliceReports(map) {
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']
-  const uncheckedCategories = getCategoriesNotDisplayed();
+  const uncheckedCategoriesElement = Array.from(document.querySelectorAll("input.category:not(:checked)"));
+  const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
+  console.log(uncheckedCategories);
 
   for (const file_name of FILE_NAMES) {
     if (!withinTimeFrame(file_name)) {
@@ -84,7 +86,7 @@ async function loadPoliceReports(map) {
     }
     const data = await fetch('../data/' + file_name + '.json');
     const reports = await data.json();
-    
+
     const filteredReports = reports.filter(report => {
       if (report.latitude == "" || report.longitude == "") {
         return false;
@@ -119,7 +121,7 @@ function displayCrimeType(uncheckedCategories, crimeType) {
 }
 
 function withinTimeFrame(filename) {
-  const userTimeFrame = Number(document.querySelector("input.time-frame[checked]").value);
+  const userTimeFrame = Number(document.querySelector("input.time-frame:checked").value);
 
   const month = Number(filename.substring(5, 7));
   const year = Number(filename.substring(0, 4));

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -61,6 +61,10 @@ window.onload = () => {
   document.getElementById('form-container').style.display = 'none';
   document.getElementById('report-button').addEventListener('click', showReportForm);
   const map = initMap();
+  const categories = Array.from(document.getElementsByClassName('category'));
+  const timeFrames = Array.from(document.getElementsByClassName('time-frame'));
+  categories.map(categoryElement => categoryElement.addEventListener('change', () => {loadPoliceReports(map)}));
+  timeFrames.map(timeFrameElement => timeFrameElement.addEventListener('change', () => {loadPoliceReports(map)}));
   loadPoliceReports(map);
   displayUserLocation(map);
 };
@@ -75,6 +79,7 @@ async function loadPoliceReports(map) {
 
   for (const file_name of FILE_NAMES) {
     if (!withinTimeFrame(file_name)) {
+      console.log(file_name);
       continue;
     }
     const data = await fetch('../data/' + file_name + '.json');

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -88,14 +88,18 @@ async function loadPoliceReports(map) {
 
   mapMarkers = await Promise.all(FILE_NAMES.map((file_name) =>
     createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths)));
-  mapMarkers = mapMarkers.flat(); 
+  mapMarkers = mapMarkers.flat();
 }
 
 async function createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths) {
   const data = await fetch('../data/' + file_name + '.json');
   const reports = await data.json();
 
-  if (reports.length !== 0 && !isReportwithinTimeFrame(reports[0].yearMonth, numberOfMonths)) {
+  const reportsDate = new Date();
+  reportsDate.setMonth(Number(reports[0].yearMonth.substring(5, 7)));
+  reportsDate.setYear(Number(reports[0].yearMonth.substring(0, 4)));
+
+  if (reports.length !== 0 && !isReportwithinTimeFrame(reportsDate, numberOfMonths)) {
     // Only check first report because all reports have same date if in same file
     return [];
   }
@@ -127,12 +131,9 @@ function displayCrimeType(uncheckedCategories, crimeType) {
   return true;
 }
 
-function isReportwithinTimeFrame(reportDate, numberOfMonths) {
-  const month = Number(reportDate.substring(5, 7));
-  const year = Number(reportDate.substring(0, 4));
-
+function isReportwithinTimeFrame(reportsDate, numberOfMonths) {
   const today = new Date();
-  const monthDiff = (today.getFullYear() - year) * 12 + today.getMonth() + 1 - month;
+  const monthDiff = (today.getFullYear() - reportsDate.getFullYear()) * 12 + today.getMonth() + 1 - reportsDate.getMonth();
 
   return (monthDiff < numberOfMonths);
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -63,6 +63,7 @@ window.onload = () => {
   const map = initMap();
   loadPoliceReports(map);
   displayUserLocation(map);
+  filter();
 };
 
 function showReportForm() {
@@ -82,5 +83,12 @@ async function loadPoliceReports(map) {
         }, map: map
       });
     };
+  }
+}
+
+function filter() {
+  const categories = document.getElementsByClassName('category');
+  for (category of categories) {
+    console.log(category)
   }
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -86,9 +86,9 @@ async function loadPoliceReports(map) {
   const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
   const numberOfMonths = Number(document.querySelector("input.time-frame:checked").value);
 
-  mapMarkers = await Promise.all(FILE_NAMES.map((file_name) =>
+  const markersArrayForEachReports = await Promise.all(FILE_NAMES.map((file_name) =>
     createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths)));
-  mapMarkers = mapMarkers.flat();
+  mapMarkers = markersArrayForEachReports.flat();
 }
 
 async function createPoliceReportMarkers(map, file_name, uncheckedCategories, numberOfMonths) {
@@ -135,5 +135,5 @@ function isReportwithinTimeFrame(reportsDate, numberOfMonths) {
   const today = new Date();
   const monthDiff = (today.getFullYear() - reportsDate.getFullYear()) * 12 + today.getMonth() + 1 - reportsDate.getMonth();
 
-  return (monthDiff < numberOfMonths);
+  return monthDiff < numberOfMonths;
 }

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+let mapMarkers = [];
 
 function initMap() {
   const map = new google.maps.Map(document.getElementById("map"), {
@@ -74,14 +75,16 @@ function showReportForm() {
 }
 
 async function loadPoliceReports(map) {
+  // Clear all markers on the map
+  mapMarkers.map(marker => marker.setMap(null));
+  mapMarkers.length = 0;
+
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']
   const uncheckedCategoriesElement = Array.from(document.querySelectorAll("input.category:not(:checked)"));
   const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
-  console.log(uncheckedCategories);
 
   for (const file_name of FILE_NAMES) {
     if (!withinTimeFrame(file_name)) {
-      console.log(file_name);
       continue;
     }
     const data = await fetch('../data/' + file_name + '.json');
@@ -100,14 +103,9 @@ async function loadPoliceReports(map) {
         lng: Number(report.longitude)
       }, map: map
     }));
-  }
-}
 
-function getCategoriesNotDisplayed() {
-  const categories = Array.from(document.getElementsByClassName('category'));
-  const uncheckedCategoriesElement = categories.filter(category => !category.checked);
-  const uncheckedCategories = uncheckedCategoriesElement.map(element => element.value);
-  return uncheckedCategories;
+    mapMarkers = mapMarkers.concat(markers);
+  }
 }
 
 function displayCrimeType(uncheckedCategories, crimeType) {

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -76,7 +76,9 @@ function showReportForm() {
 
 async function loadPoliceReports(map) {
   // Clear all markers on the map
-  mapMarkers.map(marker => marker.setMap(null));
+  for (const marker of mapMarkers) {
+    marker.setMap(null);
+  }
   mapMarkers.length = 0;
 
   const FILE_NAMES = ['2019_12_london', '2020_01_london', '2020_02_london', '2020_03_london', '2020_04_london', '2020_05_london']


### PR DESCRIPTION
When there is a change in user preference in time frame or crimetype, police data is reloaded, previous markers are cleared and only the ones that is consistent with the filtering is displayed. To avoid loading unnecessary data, for time frame, I look at filename to decide whether or not to load the data. Notice the difference in number of markers in below screenshots based on timeframe:
![Screenshot 2020-07-07 at 9 42 59 PM - Display 2](https://user-images.githubusercontent.com/43098355/86783263-0ab02000-c09b-11ea-8896-49cfedab742d.png)
![Screenshot 2020-07-07 at 9 43 05 PM - Display 2](https://user-images.githubusercontent.com/43098355/86783280-10a60100-c09b-11ea-99ba-b0aa62c47568.png)


*Currently, custom button doesn't work 
*Will change global variable to class in another refactor PR. 