### PR TITLE
Tests work with new Report class

### DIFF
--- a/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
+++ b/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
@@ -54,7 +54,7 @@ public class ReportServlet extends HttpServlet {
     }
   };
 
-  private static DateFormat timeStampFormatter = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
+  public static DateFormat timeStampFormatter = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -97,7 +97,7 @@ public class ReportServlet extends HttpServlet {
       }
     }
 
-    if (request.getParameter("image")) {
+    if (request.getParameter("image") != null) {
       reportEntity.setProperty("imageUrl", getUploadedFileUrl(request, "image"));
     }
     return reportEntity;

--- a/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
+++ b/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
@@ -54,7 +54,7 @@ public class ReportServlet extends HttpServlet {
     }
   };
 
-  public static DateFormat timeStampFormatter = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
+  private static DateFormat timeStampFormatter = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
+++ b/web-app/src/main/java/com/google/sps/servlets/ReportServlet.java
@@ -97,7 +97,9 @@ public class ReportServlet extends HttpServlet {
       }
     }
 
-    reportEntity.setProperty("imageUrl", getUploadedFileUrl(request, "image"));
+    if (request.getParameter("image")) {
+      reportEntity.setProperty("imageUrl", getUploadedFileUrl(request, "image"));
+    }
     return reportEntity;
   }
 

--- a/web-app/src/main/webapp/script.js
+++ b/web-app/src/main/webapp/script.js
@@ -188,7 +188,10 @@ function reportFormToURLQuery(latitude, longitude) {
 
   formData.append('latitude', latitude);
   formData.append('longitude', longitude);
-  formData.append('image', document.getElementById('attach-image').files[0]);
+  const image = document.getElementById('attach-image').files[0];
+  if (image) {
+    formData.append('image', image);
+  }
 
   return formData;
 }

--- a/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
+++ b/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
@@ -38,31 +38,22 @@ public class ReportServletTest extends Mockito {
   public void testReportServlet() throws IOException {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
-    String time = "2017-06-01T08:30";
 
     when(request.getParameter("title")).thenReturn("Test");
     when(request.getParameter("latitude")).thenReturn("1.11");
     when(request.getParameter("longitude")).thenReturn("10.26");
-    when(request.getParameter("timestamp")).thenReturn(time);
+    when(request.getParameter("timestamp")).thenReturn("2017-06-01T08:30");
     when(request.getParameter("incidentType")).thenReturn("Theft");
     when(request.getParameter("description")).thenReturn("Sample request for testing");
 
     Entity testReport = ReportServlet.createReportEntity(request, response);
-    Date timestamp;
-    try {
-      timestamp = ReportServlet.timeStampFormatter.parse(time);
-    } catch (Exception e) {
-      System.out.println("Failed to parse time");
-      return;
-    }
-    Long epochTime = timestamp.getTime();
 
     Assert.assertEquals(testReport.getProperty("title"), "Test");
     Assert.assertEquals(testReport.getProperty("latitude"), 1.11);
     Assert.assertEquals(testReport.getProperty("longitude"), 10.26);
     Assert.assertEquals(testReport.getProperty("incidentType"), "Theft");
     Assert.assertEquals(testReport.getProperty("description"), "Sample request for testing");
-    Assert.assertEquals(testReport.getProperty("timestamp"), epochTime);
+    Assert.assertEquals(testReport.getProperty("timestamp"), 1496305800000L);
   }
 
   @After

--- a/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
+++ b/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
@@ -15,6 +15,9 @@ import org.mockito.Mockito;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -24,8 +27,7 @@ import com.google.appengine.api.datastore.Entity;
 @RunWith(JUnit4.class)
 public class ReportServletTest extends Mockito {
 
-  private final LocalServiceTestHelper helper =
-  new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig(), new LocalBlobstoreServiceTestConfig());
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
   @Before
   public void setUp() {
@@ -36,22 +38,27 @@ public class ReportServletTest extends Mockito {
   public void testReportServlet() throws IOException {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
+    // private static DateFormat timeStampFormatter = new
+    // SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
+    String time = "2017-06-01T08:30";
 
     when(request.getParameter("title")).thenReturn("Test");
     when(request.getParameter("latitude")).thenReturn("1.11");
     when(request.getParameter("longitude")).thenReturn("10.26");
-    when(request.getParameter("timestamp")).thenReturn("2017-06-01T08:30");
+    when(request.getParameter("timestamp")).thenReturn(time);
     when(request.getParameter("incidentType")).thenReturn("Theft");
     when(request.getParameter("description")).thenReturn("Sample request for testing");
 
     Entity testReport = ReportServlet.createReportEntity(request, response);
+    Date timestamp = ReportServlet.timeStampFormatter.parse(time);
+    Long epochTime = timestamp.getTime();
 
     Assert.assertEquals(testReport.getProperty("title"), "Test");
     Assert.assertEquals(testReport.getProperty("latitude"), 1.11);
     Assert.assertEquals(testReport.getProperty("longitude"), 10.26);
     Assert.assertEquals(testReport.getProperty("incidentType"), "Theft");
     Assert.assertEquals(testReport.getProperty("description"), "Sample request for testing");
-    Assert.assertEquals(testReport.getProperty("timestamp"), 1496273400);
+    Assert.assertEquals(testReport.getProperty("timestamp"), epochTime);
   }
 
   @After

--- a/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
+++ b/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
@@ -38,8 +38,6 @@ public class ReportServletTest extends Mockito {
   public void testReportServlet() throws IOException {
     HttpServletRequest request = mock(HttpServletRequest.class);
     HttpServletResponse response = mock(HttpServletResponse.class);
-    // private static DateFormat timeStampFormatter = new
-    // SimpleDateFormat("yyyy-MM-dd'T'hh:mm");
     String time = "2017-06-01T08:30";
 
     when(request.getParameter("title")).thenReturn("Test");

--- a/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
+++ b/web-app/src/test/java/com/google/sps/servlets/ReportServletTest.java
@@ -50,7 +50,13 @@ public class ReportServletTest extends Mockito {
     when(request.getParameter("description")).thenReturn("Sample request for testing");
 
     Entity testReport = ReportServlet.createReportEntity(request, response);
-    Date timestamp = ReportServlet.timeStampFormatter.parse(time);
+    Date timestamp;
+    try {
+      timestamp = ReportServlet.timeStampFormatter.parse(time);
+    } catch (Exception e) {
+      System.out.println("Failed to parse time");
+      return;
+    }
     Long epochTime = timestamp.getTime();
 
     Assert.assertEquals(testReport.getProperty("title"), "Test");


### PR DESCRIPTION
Modify our code so that it checks if an image exists before calling getUploadUrl, allowing us to test createReportEntity without having to mock blobstore. 

I also modified how the timestamp is parsed (parse instead of hardcoding an epoch time) so the test passes across timezones.