### PR TITLE
Prevent zoom on UI

### DIFF
--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=0.5, maximum-scale=0.5, user-scalable=no" />
   <title>Be Safer</title>
   <link rel="stylesheet" href="css/skeleton.css" />
   <link rel="stylesheet" href="css/normalize.css" />
@@ -242,7 +243,7 @@
       </div>
     </div>
     <button id="select-all-times" class="menu-button">Select all</button>
-  </div>				
+  </div>
   <!-- Submit report -->
   <div id="form-container" class="report">
     <div class="row">


### PR DESCRIPTION
Closes #43. Our original styling was for a very zoomed out viewport so I reduced the scale in the meta tag to prevent oversized UI elements.