### PR TITLE
Change raw Lat Lngs to Coordinates objects

### DIFF
--- a/web-app/src/main/java/com/google/sps/data/QuadTree.java
+++ b/web-app/src/main/java/com/google/sps/data/QuadTree.java
@@ -33,7 +33,7 @@ public class QuadTree {
   }
 
   public QuadTree() {
-    Rectangle bounds = new Rectangle(90.0, -180.0, -90.0, 180.0);
+    Rectangle bounds = new Rectangle(new Coordinates(90.0, -180.0), new Coordinates(-90.0, 180.0));
     root = new Node(bounds, new ArrayList<PoliceReport>(), 0);
   }
 
@@ -84,7 +84,7 @@ public class QuadTree {
       reports.addAll(findAllReports(range, child));
     }
     return reports;
-  } 
+  }
 
   public void insert(PoliceReport report) {
     Node currentNode = root;
@@ -111,7 +111,6 @@ public class QuadTree {
       currentNode.reports = null;
     }
   }
-
 
   private Node[] reallocateReports(List<PoliceReport> reports, Rectangle bounds, int depth) {
     Node[] children = new Node[4];

--- a/web-app/src/main/java/com/google/sps/data/Rectangle.java
+++ b/web-app/src/main/java/com/google/sps/data/Rectangle.java
@@ -57,22 +57,25 @@ public class Rectangle {
   }
 
   public boolean contains(double lat, double lng) {
-    return (lat <= topLeftLat && lat >= bottomRightLat && lng >= topLeftLng && lng <= bottomRightLng);
+    return (lat <= topLeft.getLat() && lat >= bottomRight.getLat() && lng >= topLeft.getLng()
+        && lng <= bottomRight.getLng());
   }
 
   public Rectangle getNW() {
-    return new Rectangle(topLeftLat, topLeftLng, centerLat, centerLng);
+    return new Rectangle(topLeft, center);
   }
 
   public Rectangle getNE() {
-    return new Rectangle(topLeftLat, centerLng, centerLat, bottomRightLng);
+    return new Rectangle(new Coordinates(topLeft.getLat(), center.getLng()),
+        new Coordinates(center.getLat(), bottomRight.getLng()));
   }
 
   public Rectangle getSE() {
-    return new Rectangle(centerLat, centerLng, bottomRightLat, bottomRightLng);
+    return new Rectangle(center, bottomRight);
   }
 
   public Rectangle getSW() {
-    return new Rectangle(centerLat, topLeftLng, bottomRightLat, centerLng);
+    return new Rectangle(new Coordinates(center.getLat(), topLeft.getLng()),
+        new Coordinates(bottomRight.getLat(), center.getLng()));
   }
 }

--- a/web-app/src/main/java/com/google/sps/data/Rectangle.java
+++ b/web-app/src/main/java/com/google/sps/data/Rectangle.java
@@ -1,53 +1,56 @@
 package com.google.sps.data;
 
 public class Rectangle {
-  private double topLeftLat;
-  private double topLeftLng;
-  private double bottomRightLat;
-  private double bottomRightLng;
-  private double centerLat;
-  private double centerLng;
+  private Coordinates topLeft;
+  private Coordinates bottomRight;
+  private Coordinates center;
 
-  public Rectangle(double topLeftLat, double topLeftLng, double bottomRightLat, double bottomRightLng) {
-    this.topLeftLat = topLeftLat;
-    this.topLeftLng = topLeftLng;
-    this.bottomRightLat = bottomRightLat;
-    this.bottomRightLng = bottomRightLng;
-    this.centerLat = (topLeftLat + bottomRightLat) / 2;
-    this.centerLng = (topLeftLng + bottomRightLng) / 2;
+  public Rectangle(Coordinates topLeft, Coordinates bottomRight) {
+    this.topLeft = topLeft;
+    this.bottomRight = bottomRight;
+    this.center = new Coordinates((topLeft.getLat() + bottomRight.getLat()) / 2,
+        (topLeft.getLng() + bottomRight.getLng()) / 2);
+  }
+
+  public Coordinates getTopLeft() {
+    return topLeft;
   }
 
   public double getTopLeftLat() {
-    return topLeftLat;
+    return topLeft.getLat();
   }
 
   public double getTopLeftLng() {
-    return topLeftLng;
+    return topLeft.getLng();
+  }
+
+  public Coordinates getBottomRight() {
+    return bottomRight;
   }
 
   public double getBottomRightLat() {
-    return bottomRightLat;
+    return bottomRight.getLat();
   }
 
   public double getBottomRightLng() {
-    return bottomRightLng;
+    return bottomRight.getLng();
   }
 
   /**
-  * Intersects: Return true if current rectangle intersects with the input, 
-  * by checking whether there is intersection in either longitude or latitude.
-  * Two rectangles just sharing a single edge or point is not considered as
-  * intersection. 
-  */
+   * Intersects: Return true if current rectangle intersects with the input, by
+   * checking whether there is intersection in either longitude or latitude. Two
+   * rectangles just sharing a single edge or point is not considered as
+   * intersection.
+   */
   public boolean intersects(Rectangle rect) {
     // No overlap in latitude
-    if (topLeftLat <= rect.bottomRightLat || rect.topLeftLat <= bottomRightLat) {
+    if (topLeft.getLat() <= rect.getBottomRightLat() || rect.getTopLeftLat() <= bottomRight.getLat()) {
       return false;
     }
-  
-    // No overlap in longitue  
-    if (topLeftLng >= rect.bottomRightLng || rect.topLeftLng >= bottomRightLng) { 
-      return false; 
+
+    // No overlap in longitue
+    if (topLeft.getLng() >= rect.getBottomRightLng() || rect.getTopLeftLng() >= bottomRight.getLng()) {
+      return false;
     }
 
     return true;

--- a/web-app/src/test/java/com/google/sps/data/QuadTreeTest.java
+++ b/web-app/src/test/java/com/google/sps/data/QuadTreeTest.java
@@ -64,10 +64,10 @@ public class QuadTreeTest extends Mockito {
 
     @Test
     public void simpleQuery() throws IOException {
-      Rectangle queryRange = new Rectangle(85.0, 15.0, 25.0, 50.0);
+      Rectangle queryRange = new Rectangle(new Coordinates(85.0, 15.0), new Coordinates(25.0, 50.0));
       List<PoliceReport> reportsInQueryRange = simpleTree.query(queryRange);
       Assert.assertEquals(2, reportsInQueryRange.size());
-      
+
       List<String> reportsCrimeType = reportsToCrimeType(reportsInQueryRange);
       collector.checkThat("test1", IsEqual.equalTo(reportsCrimeType.get(0)));
       collector.checkThat("test5", IsEqual.equalTo(reportsCrimeType.get(1)));
@@ -75,7 +75,7 @@ public class QuadTreeTest extends Mockito {
 
     @Test
     public void overlapTwoChildrenQuery() throws IOException {
-      Rectangle queryRange = new Rectangle(40.0, -30.0, -40.0, -10.0);
+      Rectangle queryRange = new Rectangle(new Coordinates(40.0, -30.0), new Coordinates(-40.0, -10.0));
       List<PoliceReport> reportsInQueryRange = simpleTree.query(queryRange);
       Assert.assertEquals(2, reportsInQueryRange.size());
 
@@ -86,7 +86,7 @@ public class QuadTreeTest extends Mockito {
 
     @Test
     public void noReportsInRange() throws IOException {
-      Rectangle queryRange = new Rectangle(10.0, -10.0, -10.0, 10.0);
+      Rectangle queryRange = new Rectangle(new Coordinates(10.0, -10.0), new Coordinates(-10.0, 10.0));
       List<PoliceReport> reportsInQueryRange = simpleTree.query(queryRange);
       Assert.assertEquals(0, reportsInQueryRange.size());
     }

--- a/web-app/src/test/java/com/google/sps/data/RectangleTest.java
+++ b/web-app/src/test/java/com/google/sps/data/RectangleTest.java
@@ -11,8 +11,8 @@ public class RectangleTest {
 
   @Test
   public void containsOtherRectangle() {
-    Rectangle outer = new Rectangle(90.0, -180.0, -90.0, 180.0);
-    Rectangle inner = new Rectangle(70.0, 30.0, 20.0, 50.0);
+    Rectangle outer = new Rectangle(new Coordinates(90.0, -180.0), new Coordinates(-90.0, 180.0));
+    Rectangle inner = new Rectangle(new Coordinates(70.0, 30.0), new Coordinates(20.0, 50.0));
 
     Assert.assertTrue(outer.intersects(inner));
     Assert.assertTrue(inner.intersects(outer));
@@ -20,8 +20,8 @@ public class RectangleTest {
 
   @Test
   public void overlapRectangle() {
-    Rectangle r1 = new Rectangle(30.0, -10.0, -10.0, 30.0);
-    Rectangle r2 = new Rectangle(15.0, 20.0, -40.0, 50.0);
+    Rectangle r1 = new Rectangle(new Coordinates(30.0, -10.0), new Coordinates(-10.0, 30.0));
+    Rectangle r2 = new Rectangle(new Coordinates(15.0, 20.0), new Coordinates(-40.0, 50.0));
 
     Assert.assertTrue(r1.intersects(r2));
     Assert.assertTrue(r2.intersects(r1));
@@ -29,8 +29,8 @@ public class RectangleTest {
 
   @Test
   public void disjointRectangles() {
-    Rectangle r1 = new Rectangle(80.0, -20.0, 30.0, -10.0);
-    Rectangle r2 = new Rectangle(80.0, 30.0, 30.0, 50.0);
+    Rectangle r1 = new Rectangle(new Coordinates(80.0, -20.0), new Coordinates(30.0, -10.0));
+    Rectangle r2 = new Rectangle(new Coordinates(80.0, 30.0), new Coordinates(30.0, 50.0));
 
     Assert.assertFalse(r1.intersects(r2));
     Assert.assertFalse(r2.intersects(r1));


### PR DESCRIPTION
Rectangle and QuadTree (+ their associated tests) now use Coordinates objects instead of doubles. Reports (i.e police reports) still use raw Lat Lngs/doubles.