### PR TITLE
Only logged in users can post reports

### DIFF
--- a/web-app/src/main/java/com/google/sps/servlets/AnalyticsServlet.java
+++ b/web-app/src/main/java/com/google/sps/servlets/AnalyticsServlet.java
@@ -61,7 +61,7 @@ public class AnalyticsServlet extends HttpServlet {
 
   private boolean isReportNearLine(PoliceReport report, Coordinates[] waypoints) {
     Coordinates reportLocation = new Coordinates(report.getLat(), report.getLng());
-    for (int index = 0; index < waypoints.length - 1; i++) {
+    for (int index = 0; index < waypoints.length - 1; index++) {
       Coordinates start = waypoints[index];
       Coordinates end = waypoints[index + 1];
 

--- a/web-app/src/main/webapp/script/script.js
+++ b/web-app/src/main/webapp/script/script.js
@@ -39,7 +39,7 @@ window.onload = async () => {
   // Bottom dock
   document
     .getElementById("report-button")
-    .addEventListener("click", () => showReportForm(map, geocoder));
+    .addEventListener("click", async () => showReportForm(map, geocoder));
   document.getElementById("menu-button").addEventListener("click", () => {
     document.getElementById("menu").style.display = "block";
   });
@@ -131,7 +131,13 @@ function showMessageOnInfoWindow(message, position, map, infoWindow) {
   infoWindow.open(map);
 }
 
-function showReportForm(map, geocoder) {
+async function showReportForm(map, geocoder) {
+  const loginStatus = await fetchAndParseJson("/login");
+  if (!loginStatus.loggedIn) {
+    alert("Please log in to post the report!");
+    location.replace(loginStatus.url);
+  }
+
   document.getElementById("form-container").style.display = "block";
   hideHomeElements();
 


### PR DESCRIPTION
If users who is not logged in tries to post report, they get an alert message to log in, and will be redirected to the log in page. 
After they login, and click the report button again, then the report form will show up. This is to filter out some of the spams by ensuring users have valid email accounts. 