### PR TITLE
Add factory path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ web-app/target/
 # JMH
 test/src/main/java/org/sample/Reference/
 test/target/
+test/.factorypath
 
 # Compiled class file
 *.class


### PR DESCRIPTION
Factory path is generated when you manually update/clean the project.