### PR TITLE
Limit users to pan maps beyond north/south poles

### DIFF
--- a/web-app/src/main/webapp/script/script.js
+++ b/web-app/src/main/webapp/script/script.js
@@ -80,7 +80,11 @@ function initMap() {
     center: { lat: 51.5074, lng: -0.1278 },
     zoom: 13,
     disableDefaultUI: true,
-    minZoom: 2,
+    minZoom: 3,
+    restriction: {
+      latLngBounds: {north: 85, south: -85, west: -180, east: 180},
+      strictBounds: true
+    },
   });
   return map;
 }

--- a/web-app/src/main/webapp/script/script.js
+++ b/web-app/src/main/webapp/script/script.js
@@ -80,6 +80,7 @@ function initMap() {
     center: { lat: 51.5074, lng: -0.1278 },
     zoom: 13,
     disableDefaultUI: true,
+    minZoom: 2,
   });
   return map;
 }


### PR DESCRIPTION
Previously, users was able to zoom/pan unlimitedly, which sometimes made them to go completely off the map and go into grey area. To avoid that issue, zoom out level is limited, and vertical bounds on panning is enforced. 