### PR TITLE
Tap outside to close menu and police reports

### DIFF
--- a/web-app/src/main/webapp/script/loadData.js
+++ b/web-app/src/main/webapp/script/loadData.js
@@ -41,7 +41,6 @@ export async function loadPoliceReports(map) {
       const markers = createMarkers(map, filteredReports);
       for (const marker of markers) {
         marker.addListener("click", () => {
-          console.log("click");
           const contentString =
             `<div id="info-window">
             <p>${marker.crimeType}</p>

--- a/web-app/src/main/webapp/script/loadData.js
+++ b/web-app/src/main/webapp/script/loadData.js
@@ -40,13 +40,14 @@ export async function loadPoliceReports(map) {
       const filteredReports = filterReports(reports, uncheckedCategories, numberOfMonths);
       const markers = createMarkers(map, filteredReports);
       for (const marker of markers) {
-        google.maps.event.addListener(marker, "click", () => {
+        marker.addListener("click", () => {
+          console.log("click");
           const contentString =
             `<div id="info-window">
             <p>${marker.crimeType}</p>
             <p>${marker.date.getFullYear()}-${marker.date.getMonth()}</p>
             </div>`;
-          const infoWindow = new google.maps.InfoWindow({ content: infoParagraph });
+          const infoWindow = new google.maps.InfoWindow({ content: contentString });
           closeActiveWindow();
           infoWindow.open(map, marker);
           MapComponents.activeInfoWindow = infoWindow;

--- a/web-app/src/main/webapp/script/loadData.js
+++ b/web-app/src/main/webapp/script/loadData.js
@@ -46,6 +46,9 @@ export async function loadPoliceReports(map) {
             <p>${marker.crimeType}</p>
             <p>${marker.date.getFullYear()}-${marker.date.getMonth()}</p>
             </div>`;
+          if (!mapComponents.infoWindow) {
+            mapComponents.infoWindow = new google.maps.InfoWindow();
+          }
           mapComponents.infoWindow.setContent(contentString);
           mapComponents.infoWindow.open(map, marker);
         });
@@ -54,11 +57,20 @@ export async function loadPoliceReports(map) {
     })
   );
   mapComponents.mapMarkers = markersArrayForEachReports.flat();
+  map.addListener("click", closeOpenWindows);
+  document.getElementById("dock").addEventListener("click", closeOpenWindows);
+}
+
+function closeOpenWindows() {
+  if (mapComponents.infoWindow) {
+    mapComponents.infoWindow.close();
+    mapComponents.activeInfoWindow = null;
+  }
 }
 
 export function filterReports(reports, uncheckedCategories, numberOfMonths) {
   // Only check first report because all reports have same date if in same file
-  const reportsDate = new Date(reports[0].timestamp*1000);
+  const reportsDate = new Date(reports[0].timestamp * 1000);
 
   if (reports.length !== 0 && !isReportwithinTimeFrame(reportsDate, numberOfMonths)) {
     return [];
@@ -83,7 +95,7 @@ function createMarkers(map, reports) {
           lng: Number(report.longitude),
         },
         map: map,
-        date: new Date(report.timestamp*1000),
+        date: new Date(report.timestamp * 1000),
         crimeType: report.crimeType,
       })
   );
@@ -115,12 +127,15 @@ export async function fetchMarkers(map, userReports) {
     createMarkerForDisplay(map, userReport, uiState);
   });
 
-  map.addListener("click", () => {
-    if (uiState.activeInfoWindow) {
-      uiState.activeInfoWindow.close();
-      uiState.activeInfoWindow = null;
-    }
-  });
+  map.addListener("click", () => { closeOpenInfoWindows(uiState) });
+  document.getElementById("dock").addEventListener("click", () => { closeOpenInfoWindows(uiState) });
+}
+
+function closeOpenInfoWindows(uiState) {
+  if (uiState.activeInfoWindow) {
+    uiState.activeInfoWindow.close();
+    uiState.activeInfoWindow = null;
+  };
 }
 
 function createMarkerForDisplay(map, data, uiState) {

--- a/web-app/src/main/webapp/script/loadData.js
+++ b/web-app/src/main/webapp/script/loadData.js
@@ -1,7 +1,7 @@
 class MapComponents {
   constructor() {
     this.mapMarkers = [];
-    this.infoWindow = new google.maps.InfoWindow();
+    this.activeInfoWindow = new google.maps.InfoWindow();
   }
 }
 
@@ -46,8 +46,10 @@ export async function loadPoliceReports(map) {
             <p>${marker.crimeType}</p>
             <p>${marker.date.getFullYear()}-${marker.date.getMonth()}</p>
             </div>`;
-          mapComponents.infoWindow.setContent(contentString);
-          mapComponents.infoWindow.open(map, marker);
+          const infoWindow = new google.maps.InfoWindow({ content: infoParagraph });
+          closeActiveWindow();
+          infoWindow.open(map, marker);
+          MapComponents.activeInfoWindow = infoWindow;
         });
       }
       return markers;
@@ -58,7 +60,7 @@ export async function loadPoliceReports(map) {
 
 export function filterReports(reports, uncheckedCategories, numberOfMonths) {
   // Only check first report because all reports have same date if in same file
-  const reportsDate = new Date(reports[0].timestamp*1000);
+  const reportsDate = new Date(reports[0].timestamp * 1000);
 
   if (reports.length !== 0 && !isReportwithinTimeFrame(reportsDate, numberOfMonths)) {
     return [];
@@ -83,7 +85,7 @@ function createMarkers(map, reports) {
           lng: Number(report.longitude),
         },
         map: map,
-        date: new Date(report.timestamp*1000),
+        date: new Date(report.timestamp * 1000),
         crimeType: report.crimeType,
       })
   );
@@ -109,21 +111,22 @@ function isReportwithinTimeFrame(reportsDate, numberOfMonths) {
 }
 
 export async function fetchMarkers(map, userReports) {
-  let uiState = { activeInfoWindow: null };
-
   userReports.forEach((userReport) => {
-    createMarkerForDisplay(map, userReport, uiState);
+    createMarkerForDisplay(map, userReport);
   });
 
-  map.addListener("click", () => {
-    if (uiState.activeInfoWindow) {
-      uiState.activeInfoWindow.close();
-      uiState.activeInfoWindow = null;
-    }
-  });
+  map.addListener("click", closeActiveWindow);
+  document.getElementById("dock").addEventListener("click", closeActiveWindow);
 }
 
-function createMarkerForDisplay(map, data, uiState) {
+function closeActiveWindow() {
+  if (MapComponents.activeInfoWindow) {
+    MapComponents.activeInfoWindow.close();
+    MapComponents.activeInfoWindow = null;
+  }
+}
+
+function createMarkerForDisplay(map, data) {
   const marker = new google.maps.Marker({
     position: { lat: data.latitude, lng: data.longitude },
     map: map,
@@ -148,10 +151,8 @@ function createMarkerForDisplay(map, data, uiState) {
 
   const infoWindow = new google.maps.InfoWindow({ content: infoParagraph });
   marker.addListener("click", () => {
-    if (uiState.activeInfoWindow) {
-      uiState.activeInfoWindow.close();
-    }
+    closeActiveWindow();
     infoWindow.open(map, marker);
-    uiState.activeInfoWindow = infoWindow;
+    MapComponents.activeInfoWindow = infoWindow;
   });
 }

--- a/web-app/src/main/webapp/script/manipulateUI.js
+++ b/web-app/src/main/webapp/script/manipulateUI.js
@@ -46,6 +46,6 @@ function hideHomeElements() {
   }
 }
 
-function hideOptionMenu() {
+export function hideOptionMenu() {
   document.getElementById("menu").style.display = "none";
 }

--- a/web-app/src/main/webapp/script/manipulateUI.js
+++ b/web-app/src/main/webapp/script/manipulateUI.js
@@ -1,6 +1,7 @@
 export function showReportForm(map, geocoder) {
   document.getElementById("form-container").style.display = "block";
   hideHomeElements();
+  hideOptionMenu();
 
   geocoder.geocode({ location: map.getCenter() }, (results, status) => {
     if (status === "OK") {
@@ -22,12 +23,7 @@ export function hideReportForm() {
 
 export function showAnalytics() {
   document.getElementById("analytics-container").style.display = "block";
-  // TODO(ltwAshley): tap on map should close menu, making this unecessary
-  const menuElements = document.getElementsByClassName("menu");
-
-  for (const element of menuElements) {
-    element.style.display = "none";
-  }
+  hideOptionMenu();
   hideHomeElements();
 }
 
@@ -48,4 +44,8 @@ function hideHomeElements() {
   for (const element of homeElements) {
     element.style.display = "none";
   }
+}
+
+function hideOptionMenu() {
+  document.getElementById("menu").style.display = "none";
 }

--- a/web-app/src/main/webapp/script/script.js
+++ b/web-app/src/main/webapp/script/script.js
@@ -15,7 +15,7 @@
 import { fetchAndParseJson, loadPoliceReports, fetchMarkers } from "/script/loadData.js";
 import { postUserReport } from "/script/postUserData.js"
 import { setDirections } from "/script/directions.js";
-import { showReportForm, hideReportForm, showAnalytics, hideAnalytics } from "/script/manipulateUI.js"
+import { showReportForm, hideReportForm, showAnalytics, hideAnalytics, hideOptionMenu } from "/script/manipulateUI.js"
 
 window.onload = async () => {
   const geocoder = new google.maps.Geocoder();
@@ -36,6 +36,7 @@ window.onload = async () => {
     }
   });
   // Bottom dock
+  document.getElementById("dock-background").addEventListener("click", hideOptionMenu);
   document
     .getElementById("report-button")
     .addEventListener("click", async () => showReportForm(map, geocoder));
@@ -58,7 +59,8 @@ window.onload = async () => {
   // Menu
   document
     .getElementById("close-menu")
-    .addEventListener("click", () => (document.getElementById("menu").style.display = "none"));
+    .addEventListener("click", hideOptionMenu);
+  map.addListener("click", hideOptionMenu);
   const timeFrameOptions = document.getElementById("time-frame-options");
   timeFrameOptions.addEventListener('change', () => { loadPoliceReports(map) });
   const categoryOptions = document.getElementById("category-options");


### PR DESCRIPTION
Tapping on the map now closes police report info windows and the options menu (user reports already close on tap). Tapping on the dock (or on the analytics info button) also closes the menu.

Closes #67.
Closes #93.