### PR TITLE
Prevent infowindow from overlapping with other HTML elements

### DIFF
--- a/web-app/src/main/webapp/css/style.css
+++ b/web-app/src/main/webapp/css/style.css
@@ -33,14 +33,14 @@
 
 #info-window {
   font-size: 2.5em;
-  max-height: 70%;
+  max-height: 50vh;
   overflow: scroll;
 }
 
 #info-image {
   margin-left: auto;
   margin-right: auto;
-  max-height: 100%;
+  max-height: 50vh;
   max-width: 100%;
 }
 

--- a/web-app/src/main/webapp/css/style.css
+++ b/web-app/src/main/webapp/css/style.css
@@ -33,6 +33,8 @@
 
 #info-window {
   font-size: 2.5em;
+  max-height: 70%;
+  overflow: scroll;
 }
 
 #info-image {

--- a/web-app/src/main/webapp/index.html
+++ b/web-app/src/main/webapp/index.html
@@ -237,8 +237,15 @@
         <label for="category-input">Category of incident</label>
         <select class="u-full-width" type="text" id="category-input">
           <option selected disabled>Category</option>
-          <option value="foo">foo</option>
-          <option value="bar">bar</option>
+          <option value="Anti-social behaviour">Anti-social behaviour</option>
+          <option value="Burglary">Burglary</option>
+          <option value="Criminal damage and arson">Criminal Damage and Arson</option>
+          <option value="Drugs">Drugs</option>
+          <option value="Possession of weapons">Possession of Weapons</option>
+          <option value="Public order">Public order</option>
+          <option value="Theft">Theft</option>
+          <option value="Violence and sexual offences">Violence and sexual offences</option>
+          <option value="Other">Other</option>
         </select>
       </div>
       <label for="description-input">Description</label>


### PR DESCRIPTION
In some small phones, the infowindow may be too large to fit between the search bar and the dock. I restricted the height of the info window to prevent this.

Closes #89.